### PR TITLE
Create a fat jar with all deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 target
 TestUtil.java
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,24 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>with-all-deps-included</shadedClassifierName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
On target/transbank-sdk-java-<version>-with-all-deps-included.jar will now appear a uber-jar
with all the dependencies included. This is to help non-maven users, in preparation for
the arrival of the webpay and patpass SDK which will increase the number of dependencies
a lot (and thus will not be manageable by hand).

I should also change the README to instruct users that don't use maven to use our uber-jar. But without merging into master (and thus publishing the uber jar) I can't really add the instructions to download it.