### PR TITLE
Integrate Allware's PatPass SDK

### DIFF
--- a/src/main/java/cl/transbank/onepay/model/Options.java
+++ b/src/main/java/cl/transbank/onepay/model/Options.java
@@ -24,4 +24,5 @@ public class Options {
 
         return options;
     }
+
 }

--- a/src/main/java/cl/transbank/patpass/PatPassByWebpayNormal.java
+++ b/src/main/java/cl/transbank/patpass/PatPassByWebpayNormal.java
@@ -34,7 +34,7 @@ public class PatPassByWebpayNormal extends WSWebpayServiceWrapper {
         in.setFinalURL(finalUrl);
         List<WsTransactionDetail> list = in.getTransactionDetails();
         WsTransactionDetail detail = new WsTransactionDetail();
-        detail.setAmount(new BigDecimal(amount));
+        detail.setAmount(BigDecimal.valueOf(amount));
         detail.setBuyOrder(buyOrder);
         detail.setCommerceCode(config.getCommerceCode());
         list.add(detail);

--- a/src/main/java/cl/transbank/patpass/PatPassByWebpayNormal.java
+++ b/src/main/java/cl/transbank/patpass/PatPassByWebpayNormal.java
@@ -1,0 +1,64 @@
+package cl.transbank.patpass;
+
+import cl.transbank.webpay.configuration.Configuration;
+import cl.transbank.webpay.security.SoapSignature;
+import cl.transbank.webpay.wrapper.WSWebpayServiceWrapper;
+import com.transbank.webpay.wswebpay.service.*;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import java.math.BigDecimal;
+import java.util.List;
+
+public class PatPassByWebpayNormal extends WSWebpayServiceWrapper {
+    private Configuration config;
+
+    public enum Currency {
+        DEFAULT, // pesos o UF
+        UF;
+    }
+
+
+
+    public PatPassByWebpayNormal(Configuration config, SoapSignature signature) throws Exception {
+        super(config.getEnvironment(), signature);
+        this.config = config;
+    }
+
+    public WsInitTransactionOutput initTransaction(double amount, String buyOrder, String sessionId, String returnUrl, String finalUrl, PatPassInfo info) {
+        WsInitTransactionInput in = new WsInitTransactionInput();
+        in.setWSTransactionType(WsTransactionType.TR_NORMAL_WS_WPM);        
+        in.setBuyOrder(buyOrder);
+        in.setSessionId(sessionId);
+        in.setReturnURL(returnUrl);
+        in.setFinalURL(finalUrl);
+        List<WsTransactionDetail> list = in.getTransactionDetails();
+        WsTransactionDetail detail = new WsTransactionDetail();
+        detail.setAmount(new BigDecimal(amount));
+        detail.setBuyOrder(buyOrder);
+        detail.setCommerceCode(config.getCommerceCode());
+        list.add(detail);
+        
+        WpmDetailInput wpmDetail = new WpmDetailInput();
+        wpmDetail.setServiceId(info.getServiceId());
+        wpmDetail.setCardHolderId(info.getCardHolderId());
+        wpmDetail.setCardHolderName(info.getCardHolderName());
+        wpmDetail.setCardHolderLastName1(info.getCardHolderLastName1());
+        wpmDetail.setCardHolderLastName2(info.getCardHolderLastName2());
+        wpmDetail.setCardHolderMail(info.getCardHolderMail());
+        wpmDetail.setCellPhoneNumber(info.getCellPhoneNumber());
+        wpmDetail.setUfFlag(Currency.UF.equals(config.getPatPassCurrency()));
+
+        try {
+            wpmDetail.setExpirationDate(
+                    DatatypeFactory.newInstance().newXMLGregorianCalendar(
+                            info.getExpirationDate()));
+        } catch (DatatypeConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+        wpmDetail.setCommerceMail(config.getCommerceMail());
+        in.setWPMDetail(wpmDetail);
+        return this.initTransaction(in);
+    }
+          
+}

--- a/src/main/java/cl/transbank/patpass/PatPassInfo.java
+++ b/src/main/java/cl/transbank/patpass/PatPassInfo.java
@@ -1,0 +1,23 @@
+package cl.transbank.patpass;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.util.GregorianCalendar;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@NoArgsConstructor
+public class PatPassInfo {
+    private String serviceId;
+    private String cardHolderId;
+    private String cardHolderName;
+    private String cardHolderLastName1;
+    private String cardHolderLastName2;
+    private String cardHolderMail;
+    private String cellPhoneNumber;
+    private GregorianCalendar expirationDate;
+}

--- a/src/main/java/cl/transbank/webpay/Webpay.java
+++ b/src/main/java/cl/transbank/webpay/Webpay.java
@@ -1,5 +1,6 @@
 package cl.transbank.webpay;
 
+import cl.transbank.patpass.PatPassByWebpayNormal;
 import cl.transbank.webpay.configuration.Configuration;
 import cl.transbank.webpay.security.SoapSignature;
 
@@ -113,8 +114,7 @@ public class Webpay {
     }
     
     SoapSignature signature;
-    Environment mode;
-    String commerceCode;
+    Configuration configuration;
     
     WebpayNormal normalTransaction;
     WebpayOneClick oneClickTransaction;
@@ -122,6 +122,7 @@ public class Webpay {
     WebpayComplete completeTransaction;
     WebpayCapture captureTransaction;
     WebpayNullify nullifyTransaction;
+    PatPassByWebpayNormal patPassByWebpayTransaction;
 
     @Deprecated
     public Webpay(Environment env, String commerceCode, SoapSignature signature){
@@ -142,16 +143,15 @@ public class Webpay {
     }
     
     public Webpay(Configuration conf){
-        this.mode = conf.getEnvironment();
-        this.commerceCode = conf.getCommerceCode();
-        
+        this.configuration = conf;
+
         SoapSignature sig = new SoapSignature();
         sig .setPrivateCertificate(conf.getPrivateKey(), conf.getPublicCert());
         if (conf.getWebpayCert() != null) {
             // For backwards compatibility with the old libwebpay:
             sig.setWebpayCertificate(conf.getWebpayCert());
         } else {
-            sig.setWebpayCertificate(getWebPayCertificate(mode));
+            sig.setWebpayCertificate(getWebPayCertificate(conf.getEnvironment()));
         }
         setSignature(sig);
         
@@ -167,44 +167,63 @@ public class Webpay {
     
     public synchronized WebpayNormal getNormalTransaction() throws Exception {
         if (normalTransaction == null){
-            normalTransaction = new WebpayNormal(mode, commerceCode, signature);
+            normalTransaction = new WebpayNormal(
+                    configuration.getEnvironment(),
+                    configuration.getCommerceCode(), signature);
         }
         return normalTransaction;
     }
     
     public synchronized WebpayOneClick getOneClickTransaction() throws Exception {
         if (oneClickTransaction == null){
-            oneClickTransaction = new WebpayOneClick(mode, commerceCode, signature);
+            oneClickTransaction = new WebpayOneClick(
+                    configuration.getEnvironment(),
+                    configuration.getCommerceCode(), signature);
         }
         return oneClickTransaction;
     }
     
     public synchronized WebpayMallNormal getMallNormalTransaction() throws Exception {
         if (mallNormalTransaction == null){
-            mallNormalTransaction = new WebpayMallNormal(mode, commerceCode, signature);
+            mallNormalTransaction = new WebpayMallNormal(
+                    configuration.getEnvironment(),
+                    configuration.getCommerceCode(), signature);
         }
         return mallNormalTransaction;
     }
     
     public synchronized WebpayComplete getCompleteTransaction() throws Exception {
         if (completeTransaction == null){
-            completeTransaction = new WebpayComplete(mode, commerceCode, signature);
+            completeTransaction = new WebpayComplete(
+                    configuration.getEnvironment(),
+                    configuration.getCommerceCode(), signature);
         }
         return completeTransaction;
     }
     
     public synchronized WebpayCapture getCaptureTransaction() throws Exception {
         if (captureTransaction == null){
-            captureTransaction = new WebpayCapture(mode, commerceCode, signature);
+            captureTransaction = new WebpayCapture(
+                    configuration.getEnvironment(),
+                    configuration.getCommerceCode(), signature);
         }
         return captureTransaction;
     }
     
     public synchronized WebpayNullify getNullifyTransaction() throws Exception {
         if (nullifyTransaction == null){
-            nullifyTransaction = new WebpayNullify(mode, commerceCode, signature);
+            nullifyTransaction = new WebpayNullify(
+                    configuration.getEnvironment(),
+                    configuration.getCommerceCode(), signature);
         }
         return nullifyTransaction;
     }
-    
+
+    public synchronized PatPassByWebpayNormal getPatPassByWebpayTransaction() throws Exception {
+        if (patPassByWebpayTransaction == null){
+            patPassByWebpayTransaction = new PatPassByWebpayNormal(configuration, signature);
+        }
+        return patPassByWebpayTransaction;
+    }
+
 }

--- a/src/main/java/cl/transbank/webpay/configuration/Configuration.java
+++ b/src/main/java/cl/transbank/webpay/configuration/Configuration.java
@@ -5,6 +5,7 @@
  */
 package cl.transbank.webpay.configuration;
 
+import cl.transbank.patpass.PatPassByWebpayNormal;
 import cl.transbank.webpay.Webpay;
 
 import java.util.ArrayList;
@@ -15,9 +16,13 @@ public class Configuration {
     private String publicCert;
     private String webpayCert;
     private String commerceCode;
+
+    private String commerceMail;
+
     @Deprecated
     private ArrayList storeCodes;
     private Webpay.Environment environment = Webpay.Environment.INTEGRACION;
+    private PatPassByWebpayNormal.Currency patPassCurrency = PatPassByWebpayNormal.Currency.DEFAULT;
 
     public Configuration() {
     }
@@ -95,6 +100,22 @@ public class Configuration {
     @Deprecated
     public void setStoreCodes(ArrayList storeCodes) {
         this.storeCodes = storeCodes;
+    }
+
+    public String getCommerceMail() {
+        return commerceMail;
+    }
+
+    public void setCommerceMail(String commerceMail) {
+        this.commerceMail = commerceMail;
+    }
+
+    public PatPassByWebpayNormal.Currency getPatPassCurrency() {
+        return patPassCurrency;
+    }
+
+    public void setPatPassCurrency(PatPassByWebpayNormal.Currency patPassCurrency) {
+        this.patPassCurrency = patPassCurrency;
     }
 
     /**
@@ -350,6 +371,68 @@ public class Configuration {
             "XE4/CA2Yzlv/+n9JVsvFBTAyIvYfG3mqr8KdkL238sc=\n" +
             "-----END CERTIFICATE-----\n"
         );
+        return configuration;
+    }
+
+    public static Configuration forTestingPatPassByWebpayNormal(String commerceMail) {
+        Configuration configuration = new Configuration();
+
+        configuration.setCommerceCode("597020000548");
+        configuration.setPublicCert(
+            "-----BEGIN CERTIFICATE-----\n" +
+            "MIIDujCCAqICCQDHWKiW6dFYqjANBgkqhkiG9w0BAQsFADCBnjELMAkGA1UEBhMC\n" +
+            "Q0wxETAPBgNVBAgMCFNhbnRpYWdvMRIwEAYDVQQKDAlUcmFuc2JhbmsxETAPBgNV\n" +
+            "BAcMCFNhbnRpYWdvMRUwEwYDVQQDDAw1OTcwMjAwMDA1NDgxFzAVBgNVBAsMDkNh\n" +
+            "bmFsZXNSZW1vdG9zMSUwIwYJKoZIhvcNAQkBFhZpbnRlZ3JhZG9yZXNAdmFyaW9z\n" +
+            "LmNsMB4XDTE2MDYyODIwMDQ0N1oXDTI0MDYyNjIwMDQ0N1owgZ4xCzAJBgNVBAYT\n" +
+            "AkNMMREwDwYDVQQIDAhTYW50aWFnbzESMBAGA1UECgwJVHJhbnNiYW5rMREwDwYD\n" +
+            "VQQHDAhTYW50aWFnbzEVMBMGA1UEAwwMNTk3MDIwMDAwNTQ4MRcwFQYDVQQLDA5D\n" +
+            "YW5hbGVzUmVtb3RvczElMCMGCSqGSIb3DQEJARYWaW50ZWdyYWRvcmVzQHZhcmlv\n" +
+            "cy5jbDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANLeHJx5wK/9OSmM\n" +
+            "JPts4mClAMZPxNC4aRvCksiafSpdRtPSPMQYUpxdt16RJuoK4Cpsc2xrY/LfLvT+\n" +
+            "eLDcTa3LNLWsFdKh387Eut4QCddueC3mQLk1aVl1JxJeA1iPT6uuzllKL1Dy/5kM\n" +
+            "3GQSUobKQus19Lp31kZ6A3jbcdO2o/8atD117ajhCYcmOhMkbDvV1j1SiJuWZ1Qg\n" +
+            "YPZra2WZMMEThE5Q+uZnghOoGAulhaweRVL40u9gpwNGcpxY/1W+GJoujreTN39D\n" +
+            "ZhhvatJMHjkHzcr/nv0KAeylRy66THXCju9A/iLTyuMHVJTn202SWFlGiuhf89i5\n" +
+            "BdADw9ECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEARz2BbG8QGKqjUYorkCe+eaE5\n" +
+            "WnZN5q8/ihisJtsa9yXO7DUe8912094Wd/ZqwYQ1eBr0vEdwQ1Mit2lkBOkyNqR3\n" +
+            "af3/8znCxiTqvJdo4r3sp6nZV2m6zjicQwJ3aWFP8mqeTsyG3rMZBin0QaDoYCM+\n" +
+            "5qVZhQBycggsPMPnZ3fvBIslWCd6JBPYZ4agXNLdAsTmxYxjpuyOM+qTN9hdYdzb\n" +
+            "jaJ/IVa8NZrrSZU6BxooybSHNJ5+x0dc9Q/6A7txTnjTj8Iy9gfjokXRgpADpFq9\n" +
+            "mnf2hxewHnOGRcfAHBgS6vrpuAJ7/yIMewcMtu09ukFY7/d23CDPGVisDdDJwA==\n" +
+            "-----END CERTIFICATE-----"
+        );
+
+        configuration.setPrivateKey(
+            "-----BEGIN RSA PRIVATE KEY-----\n" +
+            "MIIEpQIBAAKCAQEA0t4cnHnAr/05KYwk+2ziYKUAxk/E0LhpG8KSyJp9Kl1G09I8\n" +
+            "xBhSnF23XpEm6grgKmxzbGtj8t8u9P54sNxNrcs0tawV0qHfzsS63hAJ1254LeZA\n" +
+            "uTVpWXUnEl4DWI9Pq67OWUovUPL/mQzcZBJShspC6zX0unfWRnoDeNtx07aj/xq0\n" +
+            "PXXtqOEJhyY6EyRsO9XWPVKIm5ZnVCBg9mtrZZkwwROETlD65meCE6gYC6WFrB5F\n" +
+            "UvjS72CnA0ZynFj/Vb4Ymi6Ot5M3f0NmGG9q0kweOQfNyv+e/QoB7KVHLrpMdcKO\n" +
+            "70D+ItPK4wdUlOfbTZJYWUaK6F/z2LkF0APD0QIDAQABAoIBAFrSRZpzqjViqHMn\n" +
+            "pGoSLLKZfurrQobvVn4ZYOU7/Pr5L99d5sRDAZnNl4QImq0lQAWlrlUdL/BUhkIJ\n" +
+            "NGxghqh7JFm3I7MT+3RwMVghqkt6jhKe4HOk+JoKJmj3yxMirprwcHnuxNBlyQbf\n" +
+            "jjEf3yGlDguGssB5ivXR6ZrtUWpwsK9OBiRctSeceFE4r68ldDKRFVLNURkK1AEd\n" +
+            "lCbhWp1a8W5CKvPjj6Rpq9r1kmTJA1h9NSkLum4f7aewvFhG6bHWEcjA6EWieipj\n" +
+            "2zk74/1HBDpujHJSUzTcXbiIsOVtY2Qh+74CMzHUUS41dGQNk/l/qUk7tRljwjFm\n" +
+            "PerH1FECgYEA6IKDDTbaLNsK4BefqlXZvCXbm0irxCb3XvvcsTqcDyZG0KWOCoXw\n" +
+            "B24xrsMfbheR0L6x4JUS6RM4bvTEhK4gJzDDeFhfPj2Kuav9nl1oEOZaJ5rxLlz7\n" +
+            "90g/f6kqjW3qlBVSFtz/jVrAk+lju9piHudwerjLA7TXLLm0tJZf7N0CgYEA6Cvc\n" +
+            "HzDhxdNYVakWsTBKI/uOUwt7cbHUr7OfoQA5dTxqHvFKBjrY3rgcI3/4vU3cEwRm\n" +
+            "a4X6RRSljyKAel54h4eJndP9+dB3VrOOkvuHXOLEVwwzfdaO+4FRQXR+0i9T46RK\n" +
+            "7FJy6XLfhPwZozebXbSTg/WZJ5UczVmxBYzquYUCgYEAu1t/0wQiZwbTCqS+qnmn\n" +
+            "jK9M+SJkFxn3N/joa3/5BVQouDTP8rbfJn2rV1IwX3xqqbUgjQJTTLGKRg7C1M+j\n" +
+            "ZTEsMiu0A+l/ggKPyi8mjoewmj2Gn3+aIjd7w5lDitfJsS5FCdtnqjY4/HeTQGrH\n" +
+            "qnOA9cM3BHOS+J1keii6f5kCgYEAofbO9bdtGUuJySBPY0azwgxgSlCtSjBrljLx\n" +
+            "vihg7Qc7ZOCg6l2tIxo/DwjcZntldqLQLFxnrj9sC8Fe7X7wCGQmPcNA30BtsD9M\n" +
+            "y/7KfKL5o1wwo63FS3D4VXhGbKx1kk3vspMF9ROdGLGh1Poa2bD6Y8k2kaV1VVAn\n" +
+            "rR6UNN0CgYEAgWw0NRz9X3V5K0WfrXnqBEvDiJ9MnsO3Y0SmV+zbTVYQ2zf2iYT+\n" +
+            "Wp4Tpjfc2k8s1dU33YnsrLaecB3gEFeEHJdN9qOPkk/yElVrcCKfFEUmPu7wvHZI\n" +
+            "yCLqC4NXGoXossGlQ2XPCSYacEQ5JJTtv+sBufhJZTwuqEBSGS7PurA=\n" +
+            "-----END RSA PRIVATE KEY-----"
+        );
+        configuration.setCommerceMail(commerceMail);
         return configuration;
     }
 }


### PR DESCRIPTION
This is far from being verbatim from the original legacy SDK. I
refrained from copying anyhing that was a duplicate from the Webpay
code and found out that most of it could be reused by changing any
reference to cl.transbank.patpass.* to cl.transbank.webpay.*.

(Why? Because the API is exactly the same as the Webpay Normal flow,
with a flag and some "WPM" details. WPM stands for WebPay Mensual
which is some kind of ancient/internal name for PatPass by Webpay)

I also took some different design decisions given that we don't have
to be backwards compatible here (unlike webpay where there are plenty
of people using the SDK, it's unlikely that people are using the
PatPass SDK)

- Avoid making initTransaction's parameter list too long, by
  introducing the PatPassInfo object to hold the extra information
  needed by PatPass.

- Use a enum to set the "uf flag", so that the code is more
  self-explanatory (instead of a plain boolean).

- Keep using Webpay as the "entry point" that can be used to obtain a
  "PatPass transaction".

- Use the actual product name ("PatPass by Webpay"). I kept the
  "normal" suffix given that almost every product gets additional stuff
  later on. So who knows if we might get a PatPass Mall in the future!

I kept the fact that the UF flag and the merchant email is set on the
Configuration rather than individually on each transaction. It seemed
like a good decision to me, even though it added more stuff to the
webpay.configuration.Configuration class.

The documentation is still missing, but I hope to release this in the 1.4.0 release so it is easier to test and debug (as an official artifact that transbank can also use to test and debug)