### PR TITLE
Un-deprecate Configuration#setWebpayCert

### DIFF
--- a/src/main/java/cl/transbank/webpay/Webpay.java
+++ b/src/main/java/cl/transbank/webpay/Webpay.java
@@ -148,7 +148,10 @@ public class Webpay {
         SoapSignature sig = new SoapSignature();
         sig .setPrivateCertificate(conf.getPrivateKey(), conf.getPublicCert());
         if (conf.getWebpayCert() != null) {
-            // For backwards compatibility with the old libwebpay:
+            // For backwards compatibility with the old libwebpay and in case
+            // someone wants to override the certificate
+            // (perhaps they don't want to update the SDK because of a code
+            // freeze or something like that)
             sig.setWebpayCertificate(conf.getWebpayCert());
         } else {
             sig.setWebpayCertificate(getWebPayCertificate(conf.getEnvironment()));

--- a/src/main/java/cl/transbank/webpay/configuration/Configuration.java
+++ b/src/main/java/cl/transbank/webpay/configuration/Configuration.java
@@ -66,7 +66,6 @@ public class Configuration {
         return webpayCert;
     }
 
-    @Deprecated
     public void setWebpayCert(String webpayCert) {
         this.webpayCert = webpayCert;
     }


### PR DESCRIPTION
It might be useful on special circumstances for integrators that can't easily update the SDK version.