### PR TITLE
Capture Webpay Plus Mall txs too

### DIFF
--- a/src/main/java/cl/transbank/webpay/WebpayCapture.java
+++ b/src/main/java/cl/transbank/webpay/WebpayCapture.java
@@ -13,15 +13,37 @@ public class WebpayCapture extends WSCommerceIntegrationServiceWrapper {
         super(mode, signature);
         this.commerceCode = commerceCode;
     }
-    
-    public CaptureOutput capture(String authorizationCode, BigDecimal captureAmount, String buyOrder){
+
+    /**
+     * Capture a transaction created by {@link WebpayMallNormal}, specifying the
+     * store code for the transaction to capture
+     * @param authorizationCode authorization code of the transaction to capture
+     * @param captureAmount amount to capture
+     * @param buyOrder buy order of the transaction to capture
+     * @param storeCode "commerce code" of the store associated with the transaction.
+     * @return the result of the capture operation
+     */
+    public CaptureOutput capture(String authorizationCode, BigDecimal captureAmount, String buyOrder, Long storeCode){
         CaptureInput input = new CaptureInput();
         input.setAuthorizationCode(authorizationCode);
         input.setBuyOrder(buyOrder);
         input.setCaptureAmount(captureAmount);    
-        input.setCommerceId(new Long(commerceCode));
+        input.setCommerceId(storeCode);
         return capture(input);        
-    }      
+    }
 
+    /**
+     * Capture a transaction created by {@link WebpayNormal}.
+     *
+     * It'll use the commerce code associated with the configuration passed to
+     * the {@link Webpay} instance used to create the capture transaction.
+     * @param authorizationCode authorization code of the transaction to capture
+     * @param captureAmount amount to capture
+     * @param buyOrder
+     * @return
+     */
+    public CaptureOutput capture(String authorizationCode, BigDecimal captureAmount, String buyOrder) {
+        capture(authorizationCode, captureAmount, buyOrder, Long.valueOf(commerceCode));
+    }
 
 }

--- a/src/main/java/cl/transbank/webpay/WebpayCapture.java
+++ b/src/main/java/cl/transbank/webpay/WebpayCapture.java
@@ -43,7 +43,7 @@ public class WebpayCapture extends WSCommerceIntegrationServiceWrapper {
      * @return
      */
     public CaptureOutput capture(String authorizationCode, BigDecimal captureAmount, String buyOrder) {
-        capture(authorizationCode, captureAmount, buyOrder, Long.valueOf(commerceCode));
+        return capture(authorizationCode, captureAmount, buyOrder, Long.valueOf(commerceCode));
     }
 
 }


### PR DESCRIPTION
For mall transactions the capture method requires the 'commerce code'
of the store, not the mall. And the code was always using the code
from the configuration (which for WebpayMallNormal means the mall code).

This allows to pass the commerce code, just like it's done with nullify.
