### PR TITLE
Fix incompatibility with some JAX-WS environments.

### DIFF
--- a/src/main/java/cl/transbank/webpay/wrapper/OneClickPaymentServiceWrapper.java
+++ b/src/main/java/cl/transbank/webpay/wrapper/OneClickPaymentServiceWrapper.java
@@ -8,15 +8,14 @@ public class OneClickPaymentServiceWrapper extends ServiceWrapperBase {
 
     private OneClickPaymentService port;
 
-    @Override
-    protected String getWsdlName() {
-        return "transbank-oneclick-payment-service.wsdl";
-    }
-
     protected OneClickPaymentServiceWrapper(Webpay.Environment environment, SoapSignature signature) throws Exception {
         super(environment, signature);
-        this.port = new OneClickPaymentServiceImplService(getWsdlUrl()).getOneClickPaymentServiceImplPort();
-        initPort(port);
+        this.port = initPort(
+                OneClickPaymentService.class,
+                OneClickPaymentServiceImplService.SERVICE,
+                OneClickPaymentServiceImplService.OneClickPaymentServiceImplPort,
+                "transbank-oneclick-payment-service.wsdl"
+        );
     }
 
     public OneClickInscriptionOutput initInscription(OneClickInscriptionInput input){

--- a/src/main/java/cl/transbank/webpay/wrapper/ServiceWrapperBase.java
+++ b/src/main/java/cl/transbank/webpay/wrapper/ServiceWrapperBase.java
@@ -2,6 +2,10 @@ package cl.transbank.webpay.wrapper;
 
 import cl.transbank.webpay.Webpay;
 import cl.transbank.webpay.security.SoapSignature;
+import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
+import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
+
+import javax.xml.namespace.QName;
 import java.net.URL;
 
 public abstract class ServiceWrapperBase {
@@ -9,21 +13,35 @@ public abstract class ServiceWrapperBase {
     private Webpay.Environment mode;
     private SoapSignature signature;
 
-    protected abstract String getWsdlName();
-
     protected ServiceWrapperBase(Webpay.Environment mode, SoapSignature signature) {
         this.mode = mode;
         this.signature = signature;
     }
 
-    protected void initPort(Object port) throws Exception {
-        if (signature != null) {
-            signature.applySignature(port);
-        }
+    protected <T> T initPort(Class<T> serviceClass, QName serviceName,
+                             QName servicePort, String wsdlName)
+            throws Exception {
+        JaxWsProxyFactoryBean factory = new JaxWsProxyFactoryBean();
+        factory.setServiceName(serviceName);
+        factory.setEndpointName(servicePort);
+        setFactoryWsdlURL(factory, getWsdlUrl(wsdlName));
+        T port = factory.create(serviceClass);
+        if (signature != null) { signature.applySignature(port); }
+        return port;
     }
 
-    public URL getWsdlUrl() {
-        return this.getClass().getResource("/wsdl/" + mode.getInternalName() + "/" + getWsdlName());
+    private void setFactoryWsdlURL(JaxWsProxyFactoryBean factory, URL url) {
+        // factory.setWsdlUrl receives a String and we need to pass on a
+        // URL as the WSDL lives inside the classpath. So this is the convulted
+        // way to do it:
+        ReflectionServiceFactoryBean clientFactory =
+                factory.getClientFactoryBean().getServiceFactory();
+        clientFactory.setWsdlURL(url);
+    }
+
+
+    public URL getWsdlUrl(String wsdlName) {
+        return this.getClass().getResource("/wsdl/" + mode.getInternalName() + "/" + wsdlName);
     }
 
 }

--- a/src/main/java/cl/transbank/webpay/wrapper/WSCommerceIntegrationServiceWrapper.java
+++ b/src/main/java/cl/transbank/webpay/wrapper/WSCommerceIntegrationServiceWrapper.java
@@ -4,19 +4,29 @@ import cl.transbank.webpay.Webpay;
 import cl.transbank.webpay.security.SoapSignature;
 import com.transbank.webpay.wswebpay.service.*;
 
+import javax.xml.namespace.QName;
+
 public class WSCommerceIntegrationServiceWrapper extends ServiceWrapperBase {
 
     private WSCommerceIntegrationService port;
 
-    @Override
-    protected String getWsdlName() {
-        return "transbank-ws-commerce-integration-service.wsdl";
-    }
-
     protected WSCommerceIntegrationServiceWrapper(Webpay.Environment environment, SoapSignature signature) throws Exception {
         super(environment, signature);
-        this.port = new WSCommerceIntegrationServiceImplService(getWsdlUrl()).getWSCommerceIntegrationServiceImplPort();
-        initPort(port);
+        // WSCommerceIntegrationServiceImplService was NOT generated using CXF
+        // so we are forced to copy/paste the QNames for the service and port :(
+        this.port = initPort(
+                WSCommerceIntegrationService.class,
+                new QName(
+                        "http://service.wswebpay.webpay.transbank.com/",
+                        "WSCommerceIntegrationServiceImplService"
+                ),
+                new QName(
+                        "http://service.wswebpay.webpay.transbank.com/",
+                        "WSCommerceIntegrationServiceImplPort"
+                ),
+                "transbank-ws-commerce-integration-service.wsdl"
+        );
+
     }
 
     public CaptureOutput capture(CaptureInput input){

--- a/src/main/java/cl/transbank/webpay/wrapper/WSCompleteWebpayServiceWrapper.java
+++ b/src/main/java/cl/transbank/webpay/wrapper/WSCompleteWebpayServiceWrapper.java
@@ -10,15 +10,14 @@ public class WSCompleteWebpayServiceWrapper extends ServiceWrapperBase {
 
     private WSCompleteWebpayService port;
 
-    @Override
-    protected String getWsdlName() {
-        return "transbank-ws-complete-webpay-service.wsdl";
-    }
-
     protected WSCompleteWebpayServiceWrapper(Webpay.Environment environment, SoapSignature signature) throws Exception {
         super(environment, signature);
-        this.port = new WSCompleteWebpayServiceImplService(getWsdlUrl()).getWSCompleteWebpayServiceImplPort();
-        initPort(port);
+        this.port = initPort(
+                WSCompleteWebpayService.class,
+                WSCompleteWebpayServiceImplService.SERVICE,
+                WSCompleteWebpayServiceImplService.WSCompleteWebpayServiceImplPort,
+                "transbank-ws-complete-webpay-service.wsdl"
+        );
     }
 
     public WsCompleteInitTransactionOutput initCompleteTransaction(WsCompleteInitTransactionInput input){

--- a/src/main/java/cl/transbank/webpay/wrapper/WSWebpayServiceWrapper.java
+++ b/src/main/java/cl/transbank/webpay/wrapper/WSWebpayServiceWrapper.java
@@ -3,8 +3,6 @@ package cl.transbank.webpay.wrapper;
 import cl.transbank.webpay.Webpay;
 import cl.transbank.webpay.security.SoapSignature;
 import com.transbank.webpay.wswebpay.service.*;
-import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
-import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
 
 public class WSWebpayServiceWrapper extends ServiceWrapperBase {
 

--- a/src/main/java/cl/transbank/webpay/wrapper/WSWebpayServiceWrapper.java
+++ b/src/main/java/cl/transbank/webpay/wrapper/WSWebpayServiceWrapper.java
@@ -3,18 +3,21 @@ package cl.transbank.webpay.wrapper;
 import cl.transbank.webpay.Webpay;
 import cl.transbank.webpay.security.SoapSignature;
 import com.transbank.webpay.wswebpay.service.*;
+import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
+import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
 
 public class WSWebpayServiceWrapper extends ServiceWrapperBase {
 
     private WSWebpayService port;
 
-    @Override
-    protected String getWsdlName() { return "transbank-ws-webpay-service.wsdl"; }
-
     protected  WSWebpayServiceWrapper(Webpay.Environment environment, SoapSignature signature) throws Exception {
         super(environment, signature);
-        this.port = new WSWebpayServiceImplService(getWsdlUrl()).getWSWebpayServiceImplPort();
-        initPort(port);
+        this.port = initPort(
+                WSWebpayService.class,
+                WSWebpayServiceImplService.SERVICE,
+                WSWebpayServiceImplService.WSWebpayServiceImplPort,
+                "transbank-ws-webpay-service.wsdl"
+        );
     }
 
     public WsInitTransactionOutput initTransaction(WsInitTransactionInput input){


### PR DESCRIPTION
The legacy code was expecting CXF to be the default JAX-WS provider.
If it wasn't, ClassCastExceptions were thrown when trying to use
CXF-specific features (the interceptors used for signatures and
validations) on the system-provided JAX-WS Services.

The fix is to create the Service instances ourselves using what CXF
provides: the JaxWsProxyFactoryBean. That way we ensure that our
Service instances are indeed CXF instances and therefore we can use
CXF-specific things on them.