### PR TITLE
Fix Onepay test

### DIFF
--- a/src/test/java/cl/transbank/onepay/model/test/OnepayTest.java
+++ b/src/test/java/cl/transbank/onepay/model/test/OnepayTest.java
@@ -14,6 +14,7 @@ public class OnepayTest {
     public void testSetIntegrationApiKeyAndSharedSecret() throws Exception {
         Onepay.setIntegrationType(Onepay.IntegrationType.TEST);
         Onepay.setIntegrationApiKeyAndSharedSecret();
+        Onepay.setAppScheme("schemetest");
         Assert.assertNotNull(Onepay.getApiKey());
         Assert.assertNotNull(Onepay.getSharedSecret());
         // We will actually hit the TEST endpoint. It's the best way to test that


### PR DESCRIPTION
Add AppScheme to Onepay Test
- The Onepay test does not works when it is run on IntelliJ because this is run on clean and the test does not set the AppScheme. 