### PR TITLE
Add refund transaction on Transaccion-Completa

### DIFF
--- a/src/main/java/cl/transbank/WebpayApiResponseManager.java
+++ b/src/main/java/cl/transbank/WebpayApiResponseManager.java
@@ -56,7 +56,4 @@ public class WebpayApiResponseManager {
     @SerializedName("id_query_installments") private Long idQueryInstallments;
     @SerializedName("deferred_periods") private List<FullTransactionInstallmentResponse.DeferredPeriod> deferredPeriods;
 
-
-
-
 }

--- a/src/main/java/cl/transbank/transaccioncompleta/FullTransaction.java
+++ b/src/main/java/cl/transbank/transaccioncompleta/FullTransaction.java
@@ -14,8 +14,6 @@ import lombok.Getter;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class FullTransaction {
@@ -33,8 +31,8 @@ public class FullTransaction {
 
     public static class Transaction {
         @Getter(AccessLevel.PRIVATE) private static Options options = new Options();
-        private static final String installmentURL = "/installments";
-        private static final String refundURL = "/refunds";
+        private static final String installmentURL = "installments";
+        private static final String refundURL = "refunds";
 
         public static void setCommerceCode(String commerceCode) {
             FullTransaction.Transaction.getOptions().setCommerceCode(commerceCode);
@@ -100,7 +98,7 @@ public class FullTransaction {
             options = FullTransaction.Transaction.buildOptions(options);
             final URL endpoint = new URL(String.format("%s/%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token, installmentURL));
             final WebpayApiRequest request = new TransactionInstallmentRequest(installmentsNumber);
-            
+
             try {
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.POST, request, options, FullTransactionInstallmentResponse.class);
             } catch (TransbankException e) {

--- a/src/main/java/cl/transbank/transaccioncompleta/FullTransaction.java
+++ b/src/main/java/cl/transbank/transaccioncompleta/FullTransaction.java
@@ -100,6 +100,7 @@ public class FullTransaction {
             options = FullTransaction.Transaction.buildOptions(options);
             final URL endpoint = new URL(String.format("%s/%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token, installmentURL));
             final WebpayApiRequest request = new TransactionInstallmentRequest(installmentsNumber);
+            
             try {
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.POST, request, options, FullTransactionInstallmentResponse.class);
             } catch (TransbankException e) {
@@ -113,9 +114,10 @@ public class FullTransaction {
 
         public static FullTransactionCommitResponse commit(String token, Long idQueryInstallments, byte deferredPeriodIndex, Boolean gracePeriod, Options options) throws IOException, TransactionCommitException {
             options = FullTransaction.Transaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s", getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+            final WebpayApiRequest request = new TransactionCommitRequest(idQueryInstallments, deferredPeriodIndex, gracePeriod);
+
             try {
-                final URL endpoint = new URL(String.format("%s/%s", getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
-                final WebpayApiRequest request = new TransactionCommitRequest(idQueryInstallments, deferredPeriodIndex, gracePeriod);
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.PUT, request, options, FullTransactionCommitResponse.class);
             } catch (TransbankException e) {
                 throw new TransactionCommitException(e);
@@ -128,9 +130,10 @@ public class FullTransaction {
 
         public static FullTransactionStatusResponse status(String token, Options options)
                 throws IOException, TransactionStatusException {
+            options = FullTransaction.Transaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s", getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+
             try {
-                options = FullTransaction.Transaction.buildOptions(options);
-                final URL endpoint = new URL(String.format("%s/%s", getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.GET, options, FullTransactionStatusResponse.class);
             } catch (TransbankException e) {
                 throw new TransactionStatusException(e);
@@ -144,10 +147,11 @@ public class FullTransaction {
         public static FullTransactionRefundResponse refund(String token, double amount, Options options)
                 throws IOException, TransactionRefundException {
 
+            options = FullTransaction.Transaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token, refundURL));
+            final WebpayApiRequest request = new TransactionRefundRequest(amount);
+
             try {
-                options = FullTransaction.Transaction.buildOptions(options);
-                final URL endpoint = new URL(String.format("%s/%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token, refundURL));
-                final WebpayApiRequest request = new TransactionRefundRequest(amount);
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.POST, request, options, FullTransactionRefundResponse.class);
             } catch (TransbankException e) {
                 throw new TransactionRefundException(e);

--- a/src/main/java/cl/transbank/transaccioncompleta/TransactionRefundRequest.java
+++ b/src/main/java/cl/transbank/transaccioncompleta/TransactionRefundRequest.java
@@ -1,0 +1,14 @@
+package cl.transbank.transaccioncompleta;
+
+import cl.transbank.model.WebpayApiRequest;
+import com.google.gson.annotations.SerializedName;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class TransactionRefundRequest extends WebpayApiRequest {
+    @SerializedName("amount") private double amount;
+}

--- a/src/main/java/cl/transbank/transaccioncompleta/model/FullTransactionRefundResponse.java
+++ b/src/main/java/cl/transbank/transaccioncompleta/model/FullTransactionRefundResponse.java
@@ -1,0 +1,19 @@
+package cl.transbank.transaccioncompleta.model;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class FullTransactionRefundResponse {
+    private String type;
+    private String authorizationCode;
+    private String authorizationDate;
+    private double nullifiedAmount;
+    private double balance;
+    private byte responseCode;
+
+
+}

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
@@ -8,10 +8,12 @@ import cl.transbank.webpay.WebpayApiResource;
 import cl.transbank.webpay.exception.*;
 import cl.transbank.model.WebpayApiRequest;
 import cl.transbank.webpay.webpayplus.model.*;
-import lombok.AccessLevel;
-import lombok.Getter;
+import com.google.gson.annotations.SerializedName;
+import lombok.*;
 
+import java.beans.IntrospectionException;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.*;
@@ -116,33 +118,35 @@ public class WebpayPlus {
         }
 
         public static WebpayPlusTransactionRefundResponse refund(String token, double amount)
-                throws TransactionRefundException {
+                throws IOException, TransactionRefundException {
             return WebpayPlus.Transaction.refund(token, amount, null);
         }
 
         public static WebpayPlusTransactionRefundResponse refund(String token, double amount, Options options)
-                throws TransactionRefundException {
+                throws IOException, TransactionRefundException {
+            options = WebpayPlus.Transaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s/refunds", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+            final WebpayApiRequest request = new TransactionRefundRequest(amount);
+
             try {
-                options = WebpayPlus.Transaction.buildOptions(options);
-                final URL endpoint = new URL(String.format("%s/%s/refunds", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
-                final WebpayApiRequest request = new TransactionRefundRequest(amount);
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.POST, request, options, WebpayPlusTransactionRefundResponse.class);
-            } catch (Exception e) {
+            } catch (TransbankException e) {
                 throw new TransactionRefundException(e);
             }
         }
 
-        public static WebpayPlusTransactionStatusResponse status(String token) throws TransactionStatusException {
+        public static WebpayPlusTransactionStatusResponse status(String token) throws IOException, TransactionStatusException {
             return WebpayPlus.Transaction.status(token, null);
         }
 
         public static WebpayPlusTransactionStatusResponse status(String token, Options options)
-                throws TransactionStatusException {
+                throws IOException, TransactionStatusException {
+            options = WebpayPlus.Transaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+
             try {
-                options = WebpayPlus.Transaction.buildOptions(options);
-                final URL endpoint = new URL(String.format("%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.GET, options, WebpayPlusTransactionStatusResponse.class);
-            } catch (Exception e) {
+            } catch (TransbankException e) {
                 throw new TransactionStatusException(e);
             }
         }
@@ -210,22 +214,22 @@ public class WebpayPlus {
         }
 
         public static WebpayPlusTransactionRefundResponse refund(String token, double amount)
-                throws TransactionRefundException {
+                throws IOException, TransactionRefundException {
             return WebpayPlus.DeferredTransaction.refund(token, amount, null);
         }
 
         public static WebpayPlusTransactionRefundResponse refund(String token, double amount, Options options)
-                throws TransactionRefundException {
+                throws IOException, TransactionRefundException {
             options = WebpayPlus.DeferredTransaction.buildOptions(options);
             return WebpayPlus.Transaction.refund(token, amount, options);
         }
 
-        public static WebpayPlusTransactionStatusResponse status(String token) throws TransactionStatusException {
+        public static WebpayPlusTransactionStatusResponse status(String token) throws IOException, TransactionStatusException {
             return WebpayPlus.DeferredTransaction.status(token, null);
         }
 
         public static WebpayPlusTransactionStatusResponse status(String token, Options options)
-                throws TransactionStatusException {
+                throws IOException, TransactionStatusException {
             options = WebpayPlus.DeferredTransaction.buildOptions(options);
             return WebpayPlus.Transaction.status(token, options);
         }
@@ -284,65 +288,69 @@ public class WebpayPlus {
         }
 
         public static WebpayPlusMallTransactionCreateResponse create (
-                String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details) throws TransactionCreateException {
+                String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details) throws IOException, TransactionCreateException {
             return MallTransaction.create (buyOrder, sessionId, returnUrl, details, null);
         }
 
         public static WebpayPlusMallTransactionCreateResponse create (
-                String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details, Options options) throws TransactionCreateException {
+                String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details, Options options) throws IOException, TransactionCreateException {
+            options = WebpayPlus.MallTransaction.buildOptions(options);
+            final URL endpoint = new URL(getCurrentIntegrationTypeUrl(options.getIntegrationType()));
+            WebpayApiRequest request = new MallTransactionCreateRequest(buyOrder, sessionId, returnUrl, details.getDetails());
+
             try {
-                options = WebpayPlus.MallTransaction.buildOptions(options);
-                final URL endpoint = new URL(getCurrentIntegrationTypeUrl(options.getIntegrationType()));
-                WebpayApiRequest request = new MallTransactionCreateRequest(buyOrder, sessionId, returnUrl, details.getDetails());
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.POST, request, options, WebpayPlusMallTransactionCreateResponse.class);
-            } catch (Exception e) {
+            } catch (TransbankException e) {
                 throw new TransactionCreateException(e);
             }
         }
 
-        public static WebpayPlusMallTransactionCommitResponse commit(String token) throws TransactionCommitException {
+        public static WebpayPlusMallTransactionCommitResponse commit(String token) throws IOException, TransactionCommitException {
             return WebpayPlus.MallTransaction.commit(token, null);
         }
 
         public static WebpayPlusMallTransactionCommitResponse commit(String token, Options options)
-                throws TransactionCommitException {
+                throws IOException, TransactionCommitException {
+            options = WebpayPlus.MallTransaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+
             try {
-                options = WebpayPlus.MallTransaction.buildOptions(options);
-                final URL endpoint = new URL(String.format("%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.PUT, options, WebpayPlusMallTransactionCommitResponse.class);
-            } catch (Exception e) {
+            } catch (TransbankException e) {
                 throw new TransactionCommitException(e);
             }
         }
 
         public static WebpayPlusMallTransactionRefundResponse refund(String token, String buyOrder, String commerceCode, double amount)
-                throws TransactionRefundException {
+                throws IOException, TransactionRefundException {
             return WebpayPlus.MallTransaction.refund(token, buyOrder, commerceCode, amount, null);
         }
 
         public static WebpayPlusMallTransactionRefundResponse refund(String token, String buyOrder, String commerceCode, double amount, Options options)
-                throws TransactionRefundException {
+                throws IOException, TransactionRefundException {
+            options = WebpayPlus.MallTransaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s/refunds", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+            final WebpayApiRequest request = new TransactionRefundRequest(buyOrder, commerceCode, amount);
+
             try {
-                options = WebpayPlus.MallTransaction.buildOptions(options);
-                final URL endpoint = new URL(String.format("%s/%s/refunds", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
-                final WebpayApiRequest request = new TransactionRefundRequest(buyOrder, commerceCode, amount);
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.POST, request, options, WebpayPlusMallTransactionRefundResponse.class);
-            } catch (Exception e) {
+            } catch (TransbankException e) {
                 throw new TransactionRefundException(e);
             }
         }
 
-        public static WebpayPlusMallTransactionStatusResponse status(String token) throws TransactionStatusException {
+        public static WebpayPlusMallTransactionStatusResponse status(String token) throws IOException, TransactionStatusException {
             return WebpayPlus.MallTransaction.status(token, null);
         }
 
         public static WebpayPlusMallTransactionStatusResponse status(String token, Options options)
-                throws TransactionStatusException {
+                throws IOException, TransactionStatusException {
+            options = WebpayPlus.MallTransaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+
             try {
-                options = WebpayPlus.MallTransaction.buildOptions(options);
-                final URL endpoint = new URL(String.format("%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.GET, options, WebpayPlusMallTransactionStatusResponse.class);
-            } catch (Exception e) {
+            } catch (TransbankException e) {
                 throw new TransactionStatusException(e);
             }
         }
@@ -389,43 +397,43 @@ public class WebpayPlus {
         }
 
         public static WebpayPlusMallTransactionCreateResponse create (
-                String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details) throws TransactionCreateException {
+                String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details) throws IOException, TransactionCreateException {
             return MallDeferredTransaction.create (buyOrder, sessionId, returnUrl, details, null);
         }
 
         public static WebpayPlusMallTransactionCreateResponse create (
-                String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details, Options options) throws TransactionCreateException {
+                String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details, Options options) throws IOException, TransactionCreateException {
             options = WebpayPlus.MallDeferredTransaction.buildOptions(options);
             return WebpayPlus.MallTransaction.create (buyOrder, sessionId, returnUrl, details, options);
         }
 
-        public static WebpayPlusMallTransactionCommitResponse commit(String token) throws TransactionCommitException {
+        public static WebpayPlusMallTransactionCommitResponse commit(String token) throws IOException, TransactionCommitException {
             return WebpayPlus.MallDeferredTransaction.commit(token, null);
         }
 
         public static WebpayPlusMallTransactionCommitResponse commit(String token, Options options)
-                throws TransactionCommitException {
+                throws IOException, TransactionCommitException {
             options = WebpayPlus.MallDeferredTransaction.buildOptions(options);
             return WebpayPlus.MallTransaction.commit(token, options);
         }
 
         public static WebpayPlusMallTransactionRefundResponse refund(String token, String buyOrder, String commerceCode, double amount)
-                throws TransactionRefundException {
+                throws IOException, TransactionRefundException {
             return WebpayPlus.MallDeferredTransaction.refund(token, buyOrder, commerceCode, amount, null);
         }
 
         public static WebpayPlusMallTransactionRefundResponse refund(String token, String buyOrder, String commerceCode, double amount, Options options)
-                throws TransactionRefundException {
+                throws IOException, TransactionRefundException {
             options = WebpayPlus.MallDeferredTransaction.buildOptions(options);
             return WebpayPlus.MallTransaction.refund(token, buyOrder, commerceCode, amount, options);
         }
 
-        public static WebpayPlusMallTransactionStatusResponse status(String token) throws TransactionStatusException {
+        public static WebpayPlusMallTransactionStatusResponse status(String token) throws IOException, TransactionStatusException {
             return WebpayPlus.MallDeferredTransaction.status(token, null);
         }
 
         public static WebpayPlusMallTransactionStatusResponse status(String token, Options options)
-                throws TransactionStatusException {
+                throws IOException, TransactionStatusException {
             options = WebpayPlus.MallDeferredTransaction.buildOptions(options);
             return WebpayPlus.MallTransaction.status(token, options);
         }

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
@@ -200,12 +200,12 @@ public class WebpayPlus {
             return WebpayPlus.Transaction.create(buyOrder, sessionId, amount, returnUrl, options);
         }
 
-        public static WebpayPlusTransactionCommitResponse commit(String token) throws TransactionCommitException {
+        public static WebpayPlusTransactionCommitResponse commit(String token) throws TransactionCommitException, IOException {
             return WebpayPlus.DeferredTransaction.commit(token, null);
         }
 
         public static WebpayPlusTransactionCommitResponse commit(String token, Options options)
-                throws TransactionCommitException {
+                throws TransactionCommitException, IOException {
             options = WebpayPlus.DeferredTransaction.buildOptions(options);
             return WebpayPlus.Transaction.commit(token, options);
         }

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
@@ -11,9 +11,7 @@ import cl.transbank.webpay.webpayplus.model.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 
-import java.beans.IntrospectionException;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.*;
@@ -107,9 +105,10 @@ public class WebpayPlus {
 
         public static WebpayPlusTransactionCommitResponse commit(String token, Options options)
                 throws IOException, TransactionCommitException {
+            options = WebpayPlus.Transaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+
             try {
-                options = WebpayPlus.Transaction.buildOptions(options);
-                final URL endpoint = new URL(String.format("%s/%s", WebpayPlus.getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
                 return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.PUT, options, WebpayPlusTransactionCommitResponse.class);
             } catch (TransbankException e) {
                 throw new TransactionCommitException(e);
@@ -200,12 +199,12 @@ public class WebpayPlus {
             return WebpayPlus.Transaction.create(buyOrder, sessionId, amount, returnUrl, options);
         }
 
-        public static WebpayPlusTransactionCommitResponse commit(String token) throws TransactionCommitException, IOException {
+        public static WebpayPlusTransactionCommitResponse commit(String token) throws IOException, TransactionCommitException {
             return WebpayPlus.DeferredTransaction.commit(token, null);
         }
 
         public static WebpayPlusTransactionCommitResponse commit(String token, Options options)
-                throws TransactionCommitException, IOException {
+                throws IOException, TransactionCommitException {
             options = WebpayPlus.DeferredTransaction.buildOptions(options);
             return WebpayPlus.Transaction.commit(token, options);
         }
@@ -444,4 +443,3 @@ public class WebpayPlus {
         }
     }
 }
-

--- a/src/test/java/cl/transbank/webpay/ConsoleExamples.java
+++ b/src/test/java/cl/transbank/webpay/ConsoleExamples.java
@@ -6,10 +6,7 @@ import cl.transbank.patpass.model.PatpassByWebpayTransactionCreateResponse;
 import cl.transbank.patpass.model.PatpassByWebpayTransactionRefundResponse;
 import cl.transbank.patpass.model.PatpassByWebpayTransactionStatusResponse;
 import cl.transbank.transaccioncompleta.FullTransaction;
-import cl.transbank.transaccioncompleta.model.FullTransactionCommitResponse;
-import cl.transbank.transaccioncompleta.model.FullTransactionCreateResponse;
-import cl.transbank.transaccioncompleta.model.FullTransactionInstallmentResponse;
-import cl.transbank.transaccioncompleta.model.FullTransactionStatusResponse;
+import cl.transbank.transaccioncompleta.model.*;
 import cl.transbank.webpay.exception.*;
 import cl.transbank.webpay.oneclick.OneclickMall;
 import cl.transbank.webpay.oneclick.OneclickMallDeferred;
@@ -551,6 +548,20 @@ public class ConsoleExamples {
                 e.printStackTrace();
             }
        }
+
+        logger.info("---------------------------- FullTransaction  [FullTransaction.Transaction.refund] ----------------------------");
+        {
+            String token = "e966c9b10a4e6c7c7ac79512baf18173ecfaf44c9aeb8ebb05173077b6ad8a85";
+            double amount = 1000;
+            try {
+                FullTransactionRefundResponse response = FullTransaction.Transaction.refund(token,amount);
+                System.out.println(response.toString());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }  catch (TransactionRefundException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     static String nextString(int length) {


### PR DESCRIPTION
Added delegate for Refund transaction, it requires token (string) and amount (double) as in parameters and response and object cointaining: type (string), authorization_code (string), authorization_date (string), nullified_amount (double) and balance (byte)