### PR TITLE
Update xmlsec version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
-            <version>2.0.5</version>
+            <version>2.1.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
by security is necessary  to update the xmlsec version. the change was tested with the example project.