### PR TITLE
Fix optional parameters in Transacción Completa commit method

### DIFF
--- a/src/main/java/cl/transbank/transaccioncompleta/FullTransaction.java
+++ b/src/main/java/cl/transbank/transaccioncompleta/FullTransaction.java
@@ -116,6 +116,21 @@ public class FullTransaction {
             }
         }
 
+        public static FullTransactionCommitResponse commit(String token, Long idQueryInstallments, Byte deferredPeriodIndex, Boolean gracePeriod) throws IOException, TransactionCommitException {
+            return FullTransaction.Transaction.commit(token, idQueryInstallments, deferredPeriodIndex, gracePeriod, null);
+        }
+
+        public static FullTransactionCommitResponse commit(String token, Long idQueryInstallments, Byte deferredPeriodIndex, Boolean gracePeriod, Options options) throws IOException, TransactionCommitException {
+            options = FullTransaction.Transaction.buildOptions(options);
+            final URL endpoint = new URL(String.format("%s/%s", getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));
+            final WebpayApiRequest request = new TransactionCommitRequest(idQueryInstallments, deferredPeriodIndex, gracePeriod);
+
+            try {
+                return WebpayApiResource.execute(endpoint, HttpUtil.RequestMethod.PUT, request, options, FullTransactionCommitResponse.class);
+            } catch (TransbankException e) {
+                throw new TransactionCommitException(e);
+            }
+        }
 
         /**
          * This method didn't accept null values on fields that were optional

--- a/src/main/java/cl/transbank/transaccioncompleta/FullTransaction.java
+++ b/src/main/java/cl/transbank/transaccioncompleta/FullTransaction.java
@@ -116,10 +116,23 @@ public class FullTransaction {
             }
         }
 
+
+        /**
+         * This method didn't accept null values on fields that were optional
+         *
+         * @deprecated use {@link #commit(String token, Long idQueryInstallments, Byte deferredPeriodIndex, Boolean gracePeriod)} instead.
+         */
+        @Deprecated
         public static FullTransactionCommitResponse commit(String token, Long idQueryInstallments, byte deferredPeriodIndex, Boolean gracePeriod) throws IOException, TransactionCommitException {
             return FullTransaction.Transaction.commit(token, idQueryInstallments, deferredPeriodIndex, gracePeriod, null);
         }
 
+        /**
+         * This method didn't accept null values on fields that were optional
+         *
+         * @deprecated use {@link #commit(String token, Long idQueryInstallments, Byte deferredPeriodIndex, Boolean gracePeriod, Options options)} instead.
+         */
+        @Deprecated
         public static FullTransactionCommitResponse commit(String token, Long idQueryInstallments, byte deferredPeriodIndex, Boolean gracePeriod, Options options) throws IOException, TransactionCommitException {
             options = FullTransaction.Transaction.buildOptions(options);
             final URL endpoint = new URL(String.format("%s/%s", getCurrentIntegrationTypeUrl(options.getIntegrationType()), token));

--- a/src/main/java/cl/transbank/transaccioncompleta/TransactionCommitRequest.java
+++ b/src/main/java/cl/transbank/transaccioncompleta/TransactionCommitRequest.java
@@ -8,7 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TransactionCommitRequest extends WebpayApiRequest {
-    @SerializedName("id_query_installments")  private long idQueryInstallments;
-    @SerializedName("deferred_period_index") private byte deferredPeriodIndex;
-    @SerializedName("grace_period") private boolean gracePeriod;
+    @SerializedName("id_query_installments")  private Long idQueryInstallments;
+    @SerializedName("deferred_period_index") private Byte deferredPeriodIndex;
+    @SerializedName("grace_period") private Boolean gracePeriod;
 }


### PR DESCRIPTION
Changing the underlying TransactonCommitRequest does not break the old method signatures, but you can't use null values with this change alone so I deprecated the old signatures and made two new ones that receive non primitive parameters