### PR TITLE
Fix comment that said pesos or UF and should say CLP or USD

### DIFF
--- a/src/main/java/cl/transbank/patpass/PatPassByWebpayNormal.java
+++ b/src/main/java/cl/transbank/patpass/PatPassByWebpayNormal.java
@@ -14,7 +14,7 @@ public class PatPassByWebpayNormal extends WSWebpayServiceWrapper {
     private Configuration config;
 
     public enum Currency {
-        DEFAULT, // pesos o UF
+        DEFAULT, // CLP o USD
         UF;
     }
 


### PR DESCRIPTION
Fix comment that said pesos or UF and should say CLP or USD