### PR TITLE
feat: remove default environment configuration

### DIFF
--- a/src/main/java/cl/transbank/common/BaseTransaction.java
+++ b/src/main/java/cl/transbank/common/BaseTransaction.java
@@ -11,4 +11,11 @@ public abstract class BaseTransaction {
    * The options for the transaction.
    */
   protected Options options = null;
+
+  public BaseTransaction(Options options){
+    if (options == null){
+      throw new IllegalArgumentException("Options can't be null.");
+    }
+    this.options = options;
+  }
 }

--- a/src/main/java/cl/transbank/common/BaseTransaction.java
+++ b/src/main/java/cl/transbank/common/BaseTransaction.java
@@ -12,7 +12,7 @@ public abstract class BaseTransaction {
    */
   protected Options options = null;
 
-  public BaseTransaction(Options options){
+  protected BaseTransaction(Options options){
     if (options == null){
       throw new IllegalArgumentException("Options can't be null.");
     }

--- a/src/main/java/cl/transbank/model/Options.java
+++ b/src/main/java/cl/transbank/model/Options.java
@@ -7,8 +7,6 @@ import lombok.*;
 /**
  * This abstract class represents the options that can be set for a transaction.
  */
-@NoArgsConstructor
-@AllArgsConstructor
 public abstract class Options implements Cloneable {
 
   @Getter
@@ -20,31 +18,44 @@ public abstract class Options implements Cloneable {
   @Getter
   private IntegrationType integrationType;
 
+  @Setter
+  @Getter
+  private int timeout;
+
   /**
-   * Builds the options for a transaction.
-   * @param options The options to set.
-   * @return The built options.
+   * Constructs a new Options with the specified commerce code, API key, and integration type.
+   * @param commerceCode The commerce code.
+   * @param apiKey The API key.
+   * @param integrationType The integration type.
    */
-  public Options buildOptions(Options options) {
-    Options alt = clone();
+  protected Options(
+    String commerceCode,
+    String apiKey,
+    IntegrationType integrationType
+  ) {
+    this.commerceCode = commerceCode;
+    this.apiKey = apiKey;
+    this.integrationType = integrationType;
+    this.timeout = ApiConstants.REQUEST_TIMEOUT;
+  }
 
-    // If the method receives an options object then rewrite each property, this is mandatory
-    if (null != options) {
-      if (
-        null != options.getCommerceCode() &&
-        !options.getCommerceCode().trim().isEmpty()
-      ) alt.setCommerceCode(options.getCommerceCode());
-
-      if (
-        null != options.getApiKey() && !options.getApiKey().trim().isEmpty()
-      ) alt.setApiKey(options.getApiKey());
-
-      if (null != options.getIntegrationType()) alt.setIntegrationType(
-        options.getIntegrationType()
-      );
-    }
-
-    return alt;
+  /**
+   * Constructs a new Options with the specified commerce code, API key, integration type, and timeout.
+   * @param commerceCode The commerce code.
+   * @param apiKey The API key.
+   * @param integrationType The integration type.
+   * @param timeout The time in ms to wait for a response.
+   */
+  protected Options(
+    String commerceCode,
+    String apiKey,
+    IntegrationType integrationType,
+    int timeout
+  ) {
+    this.commerceCode = commerceCode;
+    this.apiKey = apiKey;
+    this.integrationType = integrationType;
+    this.timeout = timeout;
   }
 
   /**

--- a/src/main/java/cl/transbank/model/Options.java
+++ b/src/main/java/cl/transbank/model/Options.java
@@ -9,15 +9,12 @@ import lombok.*;
  */
 public abstract class Options implements Cloneable {
 
-  @Setter
   @Getter
   private String commerceCode;
 
-  @Setter
   @Getter
   private String apiKey;
 
-  @Setter
   @Getter
   private IntegrationType integrationType;
 

--- a/src/main/java/cl/transbank/patpass/PatpassByWebpay.java
+++ b/src/main/java/cl/transbank/patpass/PatpassByWebpay.java
@@ -1,99 +1,20 @@
 package cl.transbank.patpass;
 
-import cl.transbank.common.*;
 import cl.transbank.model.Options;
-import cl.transbank.patpass.model.PatpassOptions;
-import cl.transbank.webpay.common.WebpayOptions;
 
 /**
  * This class provides methods to configure and perform transactions with the PatpassByWebpay service.
  */
 public class PatpassByWebpay {
 
-  private static Options options;
-
   /**
    * This class provides methods to configure and perform transactions with the PatpassByWebpay service.
    */
   public static class Transaction extends PatpassByWebpayTransaction {
 
-    public Transaction() {
-      this.options =
-        PatpassByWebpay.options != null
-          ? PatpassByWebpay.options
-          : new WebpayOptions(
-            IntegrationCommerceCodes.PATPASS_BY_WEBPAY,
-            IntegrationApiKeys.WEBPAY,
-            IntegrationType.TEST
-          );
-    }
-
     public Transaction(Options options) {
-      this.options = options;
+      super(options);
     }
   }
 
-  /*
-    |--------------------------------------------------------------------------
-    | Environment Configuration
-    |--------------------------------------------------------------------------
-    */
-
-  /**
-   * Configures the environment for integration.
-   * @param commerceCode The commerce code.
-   * @param apiKey The API key.
-   */
-  public static void configureForIntegration(
-    String commerceCode,
-    String apiKey
-  ) {
-    PatpassByWebpay.options =
-      new PatpassOptions(commerceCode, apiKey, IntegrationType.TEST);
-  }
-
-  /**
-   * Configures the environment for integration.
-   * @param commerceCode The commerce code.
-   * @param apiKey The API key.
-   */
-  public static void configureForProduction(
-    String commerceCode,
-    String apiKey
-  ) {
-    PatpassByWebpay.options =
-      new PatpassOptions(commerceCode, apiKey, IntegrationType.LIVE);
-  }
-
-  /**
-   * Configures the environment for testing.
-   */
-  public static void configureForTesting() {
-    configureForIntegration(
-      IntegrationCommerceCodes.PATPASS_BY_WEBPAY,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  /**
-   * Configures the environment for testing deferred transactions.
-   */
-  public static void configureForTestingDeferred() {
-    configureForIntegration(
-      IntegrationCommerceCodes.PATPASS_BY_WEBPAY,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  /**
-   * Configures the environment for mock testing.
-   */
-  public static void configureForMock() {
-    PatpassByWebpay.options =
-      new PatpassOptions(
-        IntegrationCommerceCodes.PATPASS_BY_WEBPAY,
-        IntegrationApiKeys.WEBPAY,
-        IntegrationType.SERVER_MOCK
-      );
-  }
 }

--- a/src/main/java/cl/transbank/patpass/PatpassByWebpayTransaction.java
+++ b/src/main/java/cl/transbank/patpass/PatpassByWebpayTransaction.java
@@ -3,6 +3,7 @@ package cl.transbank.patpass;
 import cl.transbank.common.ApiConstants;
 import cl.transbank.common.BaseTransaction;
 import cl.transbank.exception.TransbankException;
+import cl.transbank.model.Options;
 import cl.transbank.patpass.requests.TransactionCreateRequest;
 import cl.transbank.patpass.responses.PatpassByWebpayTransactionCommitResponse;
 import cl.transbank.patpass.responses.PatpassByWebpayTransactionCreateResponse;
@@ -19,7 +20,9 @@ import cl.transbank.webpay.common.TransactionRefundRequest;
 import java.io.IOException;
 
 abstract class PatpassByWebpayTransaction extends BaseTransaction {
-
+    public PatpassByWebpayTransaction(Options options){
+        super(options);
+    }
     public PatpassByWebpayTransactionCreateResponse create(
             String buyOrder, String sessionId, double amount, String returnUrl, String serviceId, String cardHolderId,
             String cardHolderName, String cardHolderLastName1, String cardHolderLastName2, String cardHolderMail, String cellphoneNumber,

--- a/src/main/java/cl/transbank/patpass/PatpassByWebpayTransaction.java
+++ b/src/main/java/cl/transbank/patpass/PatpassByWebpayTransaction.java
@@ -20,7 +20,7 @@ import cl.transbank.webpay.common.TransactionRefundRequest;
 import java.io.IOException;
 
 abstract class PatpassByWebpayTransaction extends BaseTransaction {
-    public PatpassByWebpayTransaction(Options options){
+    protected PatpassByWebpayTransaction(Options options){
         super(options);
     }
     public PatpassByWebpayTransactionCreateResponse create(

--- a/src/main/java/cl/transbank/patpass/PatpassComercio.java
+++ b/src/main/java/cl/transbank/patpass/PatpassComercio.java
@@ -1,6 +1,10 @@
 package cl.transbank.patpass;
 
+import cl.transbank.common.IntegrationType;
 import cl.transbank.model.Options;
+import cl.transbank.patpass.model.PatpassOptions;
+import cl.transbank.webpay.common.WebpayOptions;
+import cl.transbank.webpay.webpayplus.WebpayPlus;
 
 /**
  * This class represents the details of a MallTransactionCommit.
@@ -19,6 +23,30 @@ public class PatpassComercio {
     public Inscription(Options options) {
       super(options);
     }
+  }
+
+  /**
+   * Creates and returns an instance of `Inscription` configured for the integration environment.
+   *
+   * @param commerceCode The commerce code.
+   * @param apiKey The API key used for authentication.
+   * @return A new instance of `Inscription` configured for the test environment (IntegrationType.TEST).
+   */
+  public static Inscription buildForIntegration(String commerceCode, String apiKey)
+  {
+    return new Inscription(new PatpassOptions(commerceCode, apiKey, IntegrationType.TEST));
+  }
+
+  /**
+   * Creates and returns an instance of `Inscription` configured for the production environment.
+   *
+   * @param commerceCode The commerce code.
+   * @param apiKey The API key used for authentication.
+   * @return A new instance of `Inscription` configured for the production environment (IntegrationType.LIVE).
+   */
+  public static Inscription buildForProduction(String commerceCode, String apiKey)
+  {
+    return new Inscription(new PatpassOptions(commerceCode, apiKey, IntegrationType.LIVE));
   }
 
 }

--- a/src/main/java/cl/transbank/patpass/PatpassComercio.java
+++ b/src/main/java/cl/transbank/patpass/PatpassComercio.java
@@ -1,15 +1,11 @@
 package cl.transbank.patpass;
 
-import cl.transbank.common.*;
 import cl.transbank.model.Options;
-import cl.transbank.patpass.model.PatpassOptions;
 
 /**
  * This class represents the details of a MallTransactionCommit.
  */
 public class PatpassComercio {
-
-  private static Options options;
 
   /**
    * This class represents the details of a MallTransactionCommit.
@@ -17,89 +13,12 @@ public class PatpassComercio {
   public static class Inscription extends PatpassComercioInscription {
 
     /**
-     * Default constructor. Uses default options if none are provided.
-     */
-    public Inscription() {
-      this.options =
-        PatpassComercio.options != null
-          ? PatpassComercio.options
-          : new PatpassOptions(
-            IntegrationCommerceCodes.PATPASS_COMERCIO,
-            IntegrationApiKeys.PATPASS_COMERCIO,
-            IntegrationType.TEST
-          );
-    }
-
-    /**
      * Constructor with options. Uses provided options.
      * @param options The options to use for this transaction.
      */
     public Inscription(Options options) {
-      this.options = options;
+      super(options);
     }
   }
 
-  /*
-    |--------------------------------------------------------------------------
-    | Environment Configuration
-    |--------------------------------------------------------------------------
-    */
-
-  /**
-   * Configures the environment for integration.
-   * @param commerceCode The commerce code.
-   * @param apiKey The API key.
-   */
-  public static void configureForIntegration(
-    String commerceCode,
-    String apiKey
-  ) {
-    PatpassComercio.options =
-      new PatpassOptions(commerceCode, apiKey, IntegrationType.TEST);
-  }
-
-  /**
-   * Configures the environment for integration.
-   * @param commerceCode The commerce code.
-   * @param apiKey The API key.
-   */
-  public static void configureForProduction(
-    String commerceCode,
-    String apiKey
-  ) {
-    PatpassComercio.options =
-      new PatpassOptions(commerceCode, apiKey, IntegrationType.LIVE);
-  }
-
-  /**
-   * Configures the environment for testing.
-   */
-  public static void configureForTesting() {
-    configureForIntegration(
-      IntegrationCommerceCodes.PATPASS_COMERCIO,
-      IntegrationApiKeys.PATPASS_COMERCIO
-    );
-  }
-
-  /**
-   * Configures the environment for testing deferred transactions.
-   */
-  public static void configureForTestingDeferred() {
-    configureForIntegration(
-      IntegrationCommerceCodes.PATPASS_COMERCIO,
-      IntegrationApiKeys.PATPASS_COMERCIO
-    );
-  }
-
-  /**
-   * Configures the environment for mock testing.
-   */
-  public static void configureForMock() {
-    PatpassComercio.options =
-      new PatpassOptions(
-        IntegrationCommerceCodes.PATPASS_COMERCIO,
-        IntegrationApiKeys.PATPASS_COMERCIO,
-        IntegrationType.SERVER_MOCK
-      );
-  }
 }

--- a/src/main/java/cl/transbank/patpass/PatpassComercio.java
+++ b/src/main/java/cl/transbank/patpass/PatpassComercio.java
@@ -21,30 +21,30 @@ public class PatpassComercio {
     public Inscription(Options options) {
       super(options);
     }
-  }
 
-  /**
-   * Creates and returns an instance of `Inscription` configured for the integration environment.
-   *
-   * @param commerceCode The commerce code.
-   * @param apiKey The API key used for authentication.
-   * @return A new instance of `Inscription` configured for the test environment (IntegrationType.TEST).
-   */
-  public static Inscription buildForIntegration(String commerceCode, String apiKey)
-  {
-    return new Inscription(new PatpassOptions(commerceCode, apiKey, IntegrationType.TEST));
-  }
+    /**
+     * Creates and returns an instance of `Inscription` configured for the integration environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `Inscription` configured for the test environment (IntegrationType.TEST).
+     */
+    public static Inscription buildForIntegration(String commerceCode, String apiKey)
+    {
+      return new Inscription(new PatpassOptions(commerceCode, apiKey, IntegrationType.TEST));
+    }
 
-  /**
-   * Creates and returns an instance of `Inscription` configured for the production environment.
-   *
-   * @param commerceCode The commerce code.
-   * @param apiKey The API key used for authentication.
-   * @return A new instance of `Inscription` configured for the production environment (IntegrationType.LIVE).
-   */
-  public static Inscription buildForProduction(String commerceCode, String apiKey)
-  {
-    return new Inscription(new PatpassOptions(commerceCode, apiKey, IntegrationType.LIVE));
+    /**
+     * Creates and returns an instance of `Inscription` configured for the production environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `Inscription` configured for the production environment (IntegrationType.LIVE).
+     */
+    public static Inscription buildForProduction(String commerceCode, String apiKey)
+    {
+      return new Inscription(new PatpassOptions(commerceCode, apiKey, IntegrationType.LIVE));
+    }
   }
 
 }

--- a/src/main/java/cl/transbank/patpass/PatpassComercio.java
+++ b/src/main/java/cl/transbank/patpass/PatpassComercio.java
@@ -3,8 +3,6 @@ package cl.transbank.patpass;
 import cl.transbank.common.IntegrationType;
 import cl.transbank.model.Options;
 import cl.transbank.patpass.model.PatpassOptions;
-import cl.transbank.webpay.common.WebpayOptions;
-import cl.transbank.webpay.webpayplus.WebpayPlus;
 
 /**
  * This class represents the details of a MallTransactionCommit.

--- a/src/main/java/cl/transbank/patpass/PatpassComercioInscription.java
+++ b/src/main/java/cl/transbank/patpass/PatpassComercioInscription.java
@@ -17,7 +17,7 @@ import cl.transbank.webpay.exception.TransactionStatusException;
 import java.io.IOException;
 
 abstract class PatpassComercioInscription extends BaseTransaction {
-    public PatpassComercioInscription(Options options){
+    protected PatpassComercioInscription(Options options){
         super(options);
     }
     public PatpassComercioInscriptionStartResponse start(String url,

--- a/src/main/java/cl/transbank/patpass/PatpassComercioInscription.java
+++ b/src/main/java/cl/transbank/patpass/PatpassComercioInscription.java
@@ -3,6 +3,7 @@ package cl.transbank.patpass;
 import cl.transbank.common.ApiConstants;
 import cl.transbank.common.BaseTransaction;
 import cl.transbank.exception.TransbankException;
+import cl.transbank.model.Options;
 import cl.transbank.model.WebpayApiRequest;
 import cl.transbank.patpass.requests.PatpassComercioTransactionStatusRequest;
 import cl.transbank.patpass.responses.PatpassComercioInscriptionStartResponse;
@@ -16,7 +17,9 @@ import cl.transbank.webpay.exception.TransactionStatusException;
 import java.io.IOException;
 
 abstract class PatpassComercioInscription extends BaseTransaction {
-
+    public PatpassComercioInscription(Options options){
+        super(options);
+    }
     public PatpassComercioInscriptionStartResponse start(String url,
                                                                 String name,
                                                                 String lastName,

--- a/src/main/java/cl/transbank/webpay/modal/WebpayModalTransaction.java
+++ b/src/main/java/cl/transbank/webpay/modal/WebpayModalTransaction.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 abstract class WebpayModalTransaction extends BaseTransaction {
 
     public WebpayModalTransaction(Options options){
-        this.options = options;
+        super(options);
     }
 
     public ModalTransactionCreateResponse create(String buyOrder, String sessionId, double amount) throws IOException, TransactionCreateException {

--- a/src/main/java/cl/transbank/webpay/modal/WebpayModalTransaction.java
+++ b/src/main/java/cl/transbank/webpay/modal/WebpayModalTransaction.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 abstract class WebpayModalTransaction extends BaseTransaction {
 
-    public WebpayModalTransaction(Options options){
+    protected WebpayModalTransaction(Options options){
         super(options);
     }
 

--- a/src/main/java/cl/transbank/webpay/modal/WebpayPlusModal.java
+++ b/src/main/java/cl/transbank/webpay/modal/WebpayPlusModal.java
@@ -1,37 +1,16 @@
 package cl.transbank.webpay.modal;
 
-import cl.transbank.common.IntegrationApiKeys;
-import cl.transbank.common.IntegrationCommerceCodes;
-import cl.transbank.common.IntegrationType;
 import cl.transbank.model.Options;
-import cl.transbank.webpay.common.WebpayOptions;
 
 /**
  * This class provides methods to configure and perform transactions with the PatpassByWebpay service.
  */
 public class WebpayPlusModal {
 
-  private static Options options;
-
   /**
    * This class provides methods to configure and perform transactions with the WebpayPlusModal service.
    */
   public static class Transaction extends WebpayModalTransaction {
-
-    /**
-     * Default constructor. Uses default options if none are provided.
-     */
-    public Transaction() {
-      super(
-        WebpayPlusModal.options != null
-          ? WebpayPlusModal.options
-          : new WebpayOptions(
-            IntegrationCommerceCodes.WEBPAY_PLUS_MODAL,
-            IntegrationApiKeys.WEBPAY,
-            IntegrationType.TEST
-          )
-      );
-    }
 
     /**
      * Constructor with options. Uses provided options.
@@ -42,44 +21,4 @@ public class WebpayPlusModal {
     }
   }
 
-  /*
-    |--------------------------------------------------------------------------
-    | Environment Configuration
-    |--------------------------------------------------------------------------
-    */
-
-  /**
-   * Configures the environment for integration.
-   * @param commerceCode The commerce code.
-   * @param apiKey The API key.
-   */
-  public static void configureForIntegration(
-    String commerceCode,
-    String apiKey
-  ) {
-    options = new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST);
-  }
-
-  public static void configureForProduction(
-    String commerceCode,
-    String apiKey
-  ) {
-    options = new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE);
-  }
-
-  public static void configureForTesting() {
-    configureForIntegration(
-      IntegrationCommerceCodes.WEBPAY_PLUS_MODAL,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  public static void configureForMock() {
-    options =
-      new WebpayOptions(
-        IntegrationCommerceCodes.WEBPAY_PLUS_MODAL,
-        IntegrationApiKeys.WEBPAY,
-        IntegrationType.SERVER_MOCK
-      );
-  }
 }

--- a/src/main/java/cl/transbank/webpay/oneclick/Oneclick.java
+++ b/src/main/java/cl/transbank/webpay/oneclick/Oneclick.java
@@ -1,6 +1,8 @@
 package cl.transbank.webpay.oneclick;
 
+import cl.transbank.common.IntegrationType;
 import cl.transbank.model.Options;
+import cl.transbank.webpay.common.WebpayOptions;
 
 /**
  * This class provides methods to configure and perform transactions with the Oneclick service.
@@ -15,6 +17,30 @@ public class Oneclick {
     public MallInscription(Options options) {
       super(options);
     }
+
+    /**
+     * Creates and returns an instance of `MallInscription` configured for the integration environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `MallInscription` configured for the test environment (IntegrationType.TEST).
+     */
+    public static MallInscription buildForIntegration(String commerceCode, String apiKey)
+    {
+      return new Oneclick.MallInscription(new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST));
+    }
+
+    /**
+     * Creates and returns an instance of `MallInscription` configured for the production environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `MallInscription` configured for the production environment (IntegrationType.LIVE).
+     */
+    public static MallInscription buildForProduction(String commerceCode, String apiKey)
+    {
+      return new Oneclick.MallInscription(new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE));
+    }
   }
 
   /**
@@ -24,6 +50,30 @@ public class Oneclick {
 
     public MallTransaction(Options options) {
       super(options);
+    }
+
+    /**
+     * Creates and returns an instance of `MallTransaction` configured for the integration environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `MallTransaction` configured for the test environment (IntegrationType.TEST).
+     */
+    public static MallTransaction buildForIntegration(String commerceCode, String apiKey)
+    {
+      return new Oneclick.MallTransaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST));
+    }
+
+    /**
+     * Creates and returns an instance of `MallTransaction` configured for the production environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `MallTransaction` configured for the production environment (IntegrationType.LIVE).
+     */
+    public static MallTransaction buildForProduction(String commerceCode, String apiKey)
+    {
+      return new Oneclick.MallTransaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE));
     }
   }
 

--- a/src/main/java/cl/transbank/webpay/oneclick/Oneclick.java
+++ b/src/main/java/cl/transbank/webpay/oneclick/Oneclick.java
@@ -1,34 +1,16 @@
 package cl.transbank.webpay.oneclick;
 
-import cl.transbank.common.IntegrationApiKeys;
-import cl.transbank.common.IntegrationCommerceCodes;
-import cl.transbank.common.IntegrationType;
 import cl.transbank.model.Options;
-import cl.transbank.webpay.common.WebpayOptions;
 
 /**
  * This class provides methods to configure and perform transactions with the Oneclick service.
  */
 public class Oneclick {
 
-  private static Options options;
-
   /**
    * This class provides methods to perform Oneclick Mall Inscriptions.
    */
   public static class MallInscription extends OneclickMallInscription {
-
-    public MallInscription() {
-      super(
-        Oneclick.options != null
-          ? Oneclick.options
-          : new WebpayOptions(
-            IntegrationCommerceCodes.ONECLICK_MALL,
-            IntegrationApiKeys.WEBPAY,
-            IntegrationType.TEST
-          )
-      );
-    }
 
     public MallInscription(Options options) {
       super(options);
@@ -40,63 +22,9 @@ public class Oneclick {
    */
   public static class MallTransaction extends OneclickMallTransaction {
 
-    public MallTransaction() {
-      super(
-        Oneclick.options != null
-          ? Oneclick.options
-          : new WebpayOptions(
-            IntegrationCommerceCodes.ONECLICK_MALL,
-            IntegrationApiKeys.WEBPAY,
-            IntegrationType.TEST
-          )
-      );
-    }
-
     public MallTransaction(Options options) {
       super(options);
     }
   }
 
-  /*
-    |--------------------------------------------------------------------------
-    | Environment Configuration
-    |--------------------------------------------------------------------------
-    */
-
-  public static void configureForIntegration(
-    String commerceCode,
-    String apiKey
-  ) {
-    options = new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST);
-  }
-
-  public static void configureForProduction(
-    String commerceCode,
-    String apiKey
-  ) {
-    options = new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE);
-  }
-
-  public static void configureForTesting() {
-    configureForIntegration(
-      IntegrationCommerceCodes.ONECLICK_MALL,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  public static void configureForTestingDeferred() {
-    configureForIntegration(
-      IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  public static void configureForMock() {
-    options =
-      new WebpayOptions(
-        IntegrationCommerceCodes.ONECLICK_MALL,
-        IntegrationApiKeys.WEBPAY,
-        IntegrationType.SERVER_MOCK
-      );
-  }
 }

--- a/src/main/java/cl/transbank/webpay/oneclick/OneclickMallInscription.java
+++ b/src/main/java/cl/transbank/webpay/oneclick/OneclickMallInscription.java
@@ -26,7 +26,7 @@ abstract class OneclickMallInscription extends BaseTransaction {
    * This abstract class represents the OneclickMallInscription and provides methods to handle Oneclick Mall Inscriptions.
    */
   public OneclickMallInscription(Options options) {
-    this.options = options;
+    super(options);
   }
 
   /**

--- a/src/main/java/cl/transbank/webpay/oneclick/OneclickMallInscription.java
+++ b/src/main/java/cl/transbank/webpay/oneclick/OneclickMallInscription.java
@@ -25,7 +25,7 @@ abstract class OneclickMallInscription extends BaseTransaction {
   /**
    * This abstract class represents the OneclickMallInscription and provides methods to handle Oneclick Mall Inscriptions.
    */
-  public OneclickMallInscription(Options options) {
+  protected OneclickMallInscription(Options options) {
     super(options);
   }
 

--- a/src/main/java/cl/transbank/webpay/oneclick/OneclickMallTransaction.java
+++ b/src/main/java/cl/transbank/webpay/oneclick/OneclickMallTransaction.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 abstract class OneclickMallTransaction extends BaseTransaction {
 
     public OneclickMallTransaction(Options options){
-        this.options = options;
+        super(options);
     }
     public OneclickMallTransactionAuthorizeResponse authorize(String username, String tbkUser, String parentBuyOrder, MallTransactionCreateDetails details) throws IOException, TransactionAuthorizeException {
 

--- a/src/main/java/cl/transbank/webpay/transaccioncompleta/FullTransaction.java
+++ b/src/main/java/cl/transbank/webpay/transaccioncompleta/FullTransaction.java
@@ -24,28 +24,12 @@ import java.io.IOException;
  */
 public class FullTransaction extends BaseTransaction {
 
-  private static Options defaultOptions = null;
-
-  /**
-   * Default constructor. Uses default options if none are provided.
-   */
-  public FullTransaction() {
-    this.options =
-      FullTransaction.defaultOptions != null
-        ? FullTransaction.defaultOptions
-        : new WebpayOptions(
-          IntegrationCommerceCodes.TRANSACCION_COMPLETA,
-          IntegrationApiKeys.WEBPAY,
-          IntegrationType.TEST
-        );
-  }
-
   /**
    * Constructor with options. Uses provided options.
    * @param options The options to use for this transaction.
    */
   public FullTransaction(Options options) {
-    this.options = options;
+    super(options);
   }
 
   /**
@@ -316,55 +300,4 @@ public class FullTransaction extends BaseTransaction {
     }
   }
 
-  /*
-    |--------------------------------------------------------------------------
-    | Environment Configuration
-    |--------------------------------------------------------------------------
-    */
-
-  /**
-   * Configures the transaction for integration environment.
-   * @param commerceCode The commerce code.
-   * @param apiKey The api key.
-   */
-  public static void configureForIntegration(
-    String commerceCode,
-    String apiKey
-  ) {
-    FullTransaction.defaultOptions =
-      new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST);
-  }
-
-  /**
-   * Configures the transaction for production environment.
-   * @param commerceCode The commerce code.
-   * @param apiKey The api key.
-   */
-  public static void configureForProduction(
-    String commerceCode,
-    String apiKey
-  ) {
-    FullTransaction.defaultOptions =
-      new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE);
-  }
-
-  /**
-   * Configures the transaction for testing environment.
-   */
-  public static void configureForTesting() {
-    configureForIntegration(
-      IntegrationCommerceCodes.TRANSACCION_COMPLETA,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  /**
-   * Configures the transaction for testing deferred environment.
-   */
-  public static void configureForTestingDeferred() {
-    configureForIntegration(
-      IntegrationCommerceCodes.TRANSACCION_COMPLETA_DEFERRED,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
 }

--- a/src/main/java/cl/transbank/webpay/transaccioncompleta/FullTransaction.java
+++ b/src/main/java/cl/transbank/webpay/transaccioncompleta/FullTransaction.java
@@ -33,6 +33,30 @@ public class FullTransaction extends BaseTransaction {
   }
 
   /**
+   * Creates and returns an instance of `FullTransaction` configured for the integration environment.
+   *
+   * @param commerceCode The commerce code.
+   * @param apiKey The API key used for authentication.
+   * @return A new instance of `FullTransaction` configured for the test environment (IntegrationType.TEST).
+   */
+  public static FullTransaction buildForIntegration(String commerceCode, String apiKey)
+  {
+    return new FullTransaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST));
+  }
+
+  /**
+   * Creates and returns an instance of `FullTransaction` configured for the production environment.
+   *
+   * @param commerceCode The commerce code.
+   * @param apiKey The API key used for authentication.
+   * @return A new instance of `FullTransaction` configured for the production environment (IntegrationType.LIVE).
+   */
+  public static FullTransaction buildForProduction(String commerceCode, String apiKey)
+  {
+    return new FullTransaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE));
+  }
+
+  /**
    * Creates a new FullTransaction.
    * @param buyOrder The buy order.
    * @param sessionId The session id.

--- a/src/main/java/cl/transbank/webpay/transaccioncompleta/MallFullTransaction.java
+++ b/src/main/java/cl/transbank/webpay/transaccioncompleta/MallFullTransaction.java
@@ -10,6 +10,7 @@ import cl.transbank.util.ValidationUtil;
 import cl.transbank.util.WebpayApiResource;
 import cl.transbank.webpay.common.MallTransactionCaptureRequest;
 import cl.transbank.webpay.common.MallTransactionRefundRequest;
+import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.*;
 import cl.transbank.webpay.transaccioncompleta.model.*;
 import cl.transbank.webpay.transaccioncompleta.requests.*;
@@ -27,6 +28,30 @@ public class MallFullTransaction extends BaseTransaction {
    */
   public MallFullTransaction(Options options) {
     super(options);
+  }
+
+  /**
+   * Creates and returns an instance of `MallFullTransaction` configured for the integration environment.
+   *
+   * @param commerceCode The commerce code.
+   * @param apiKey The API key used for authentication.
+   * @return A new instance of `MallFullTransaction` configured for the test environment (IntegrationType.TEST).
+   */
+  public static MallFullTransaction buildForIntegration(String commerceCode, String apiKey)
+  {
+    return new MallFullTransaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST));
+  }
+
+  /**
+   * Creates and returns an instance of `MallFullTransaction` configured for the production environment.
+   *
+   * @param commerceCode The commerce code.
+   * @param apiKey The API key used for authentication.
+   * @return A new instance of `MallFullTransaction` configured for the production environment (IntegrationType.LIVE).
+   */
+  public static MallFullTransaction buildForProduction(String commerceCode, String apiKey)
+  {
+    return new MallFullTransaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE));
   }
 
   public MallFullTransactionCreateResponse create(

--- a/src/main/java/cl/transbank/webpay/transaccioncompleta/MallFullTransaction.java
+++ b/src/main/java/cl/transbank/webpay/transaccioncompleta/MallFullTransaction.java
@@ -10,7 +10,6 @@ import cl.transbank.util.ValidationUtil;
 import cl.transbank.util.WebpayApiResource;
 import cl.transbank.webpay.common.MallTransactionCaptureRequest;
 import cl.transbank.webpay.common.MallTransactionRefundRequest;
-import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.*;
 import cl.transbank.webpay.transaccioncompleta.model.*;
 import cl.transbank.webpay.transaccioncompleta.requests.*;
@@ -22,28 +21,12 @@ import java.io.IOException;
  */
 public class MallFullTransaction extends BaseTransaction {
 
-  private static Options defaultOptions = null;
-
-  /**
-   * Default constructor. Uses default options if none are provided.
-   */
-  public MallFullTransaction() {
-    this.options =
-      MallFullTransaction.defaultOptions != null
-        ? MallFullTransaction.defaultOptions
-        : new WebpayOptions(
-          IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
-          IntegrationApiKeys.WEBPAY,
-          IntegrationType.TEST
-        );
-  }
-
   /**
    * Constructor with options. Uses provided options.
    * @param options The options to use for this transaction.
    */
   public MallFullTransaction(Options options) {
-    this.options = options;
+    super(options);
   }
 
   public MallFullTransactionCreateResponse create(
@@ -324,39 +307,4 @@ public class MallFullTransaction extends BaseTransaction {
     }
   }
 
-  /*
-    |--------------------------------------------------------------------------
-    | Environment Configuration
-    |--------------------------------------------------------------------------
-    */
-
-  public static void configureForIntegration(
-    String commerceCode,
-    String apiKey
-  ) {
-    MallFullTransaction.defaultOptions =
-      new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST);
-  }
-
-  public static void configureForProduction(
-    String commerceCode,
-    String apiKey
-  ) {
-    MallFullTransaction.defaultOptions =
-      new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE);
-  }
-
-  public static void configureForTesting() {
-    configureForIntegration(
-      IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  public static void configureForTestingDeferred() {
-    configureForIntegration(
-      IntegrationCommerceCodes.TRANSACCION_COMPLETA_MALL_DEFERRED,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
 }

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayMallTransaction.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayMallTransaction.java
@@ -17,7 +17,7 @@ import cl.transbank.webpay.webpayplus.responses.*;
 import java.io.IOException;
 
 abstract class WebpayMallTransaction extends BaseTransaction {
-    public WebpayMallTransaction(Options options){
+    protected WebpayMallTransaction(Options options){
         super(options);
     }
 

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayMallTransaction.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayMallTransaction.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 
 abstract class WebpayMallTransaction extends BaseTransaction {
     public WebpayMallTransaction(Options options){
-        this.options = options;
+        super(options);
     }
 
     public WebpayPlusMallTransactionCreateResponse create(String buyOrder, String sessionId, String returnUrl, MallTransactionCreateDetails details) throws IOException, TransactionCreateException {

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
@@ -1,6 +1,8 @@
 package cl.transbank.webpay.webpayplus;
 
+import cl.transbank.common.IntegrationType;
 import cl.transbank.model.Options;
+import cl.transbank.webpay.common.WebpayOptions;
 
 /**
  * This class provides methods to configure and perform transactions with the WebpayPlus service.
@@ -19,6 +21,30 @@ public class WebpayPlus {
     public Transaction(Options options) {
       super(options);
     }
+
+    /**
+     * Creates and returns an instance of `Transaction` configured for the integration environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `Transaction` configured for the test environment (IntegrationType.TEST).
+     */
+    public static Transaction buildForIntegration(String commerceCode, String apiKey)
+    {
+      return new Transaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST));
+    }
+
+    /**
+     * Creates and returns an instance of `Transaction` configured for the production environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `Transaction` configured for the production environment (IntegrationType.LIVE).
+     */
+    public static Transaction buildForProduction(String commerceCode, String apiKey)
+    {
+      return new Transaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE));
+    }
   }
 
   /**
@@ -32,6 +58,30 @@ public class WebpayPlus {
      */
     public MallTransaction(Options options) {
       super(options);
+    }
+
+    /**
+     * Creates and returns an instance of `MallTransaction` configured for the integration environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `MallTransaction` configured for the test environment (IntegrationType.TEST).
+     */
+    public static MallTransaction buildForIntegration(String commerceCode, String apiKey)
+    {
+      return new MallTransaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST));
+    }
+
+    /**
+     * Creates and returns an instance of `MallTransaction` configured for the production environment.
+     *
+     * @param commerceCode The commerce code.
+     * @param apiKey The API key used for authentication.
+     * @return A new instance of `MallTransaction` configured for the production environment (IntegrationType.LIVE).
+     */
+    public static MallTransaction buildForProduction(String commerceCode, String apiKey)
+    {
+      return new MallTransaction(new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE));
     }
   }
 

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayPlus.java
@@ -1,37 +1,16 @@
 package cl.transbank.webpay.webpayplus;
 
-import cl.transbank.common.IntegrationApiKeys;
-import cl.transbank.common.IntegrationCommerceCodes;
-import cl.transbank.common.IntegrationType;
 import cl.transbank.model.Options;
-import cl.transbank.webpay.common.WebpayOptions;
 
 /**
  * This class provides methods to configure and perform transactions with the WebpayPlus service.
  */
 public class WebpayPlus {
 
-  private static Options options;
-
   /**
    * This class provides methods to perform WebpayPlus Transactions.
    */
   public static class Transaction extends WebpayTransaction {
-
-    /**
-     * Default constructor. Uses default options if none are provided.
-     */
-    public Transaction() {
-      super(
-        WebpayPlus.options != null
-          ? WebpayPlus.options
-          : new WebpayOptions(
-            IntegrationCommerceCodes.WEBPAY_PLUS,
-            IntegrationApiKeys.WEBPAY,
-            IntegrationType.TEST
-          )
-      );
-    }
 
     /**
      * Constructor with options. Uses provided options.
@@ -48,21 +27,6 @@ public class WebpayPlus {
   public static class MallTransaction extends WebpayMallTransaction {
 
     /**
-     * Default constructor. Uses default options if none are provided.
-     */
-    public MallTransaction() {
-      super(
-        WebpayPlus.options != null
-          ? WebpayPlus.options
-          : new WebpayOptions(
-            IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
-            IntegrationApiKeys.WEBPAY,
-            IntegrationType.TEST
-          )
-      );
-    }
-
-    /**
      * Constructor with options. Uses provided options.
      * @param options The options to use for this transaction.
      */
@@ -71,63 +35,4 @@ public class WebpayPlus {
     }
   }
 
-  /*
-
-
-
-    |--------------------------------------------------------------------------
-    | Environment Configuration
-    |--------------------------------------------------------------------------
-    */
-
-  public static void configureForIntegration(
-    String commerceCode,
-    String apiKey
-  ) {
-    options = new WebpayOptions(commerceCode, apiKey, IntegrationType.TEST);
-  }
-
-  public static void configureForProduction(
-    String commerceCode,
-    String apiKey
-  ) {
-    options = new WebpayOptions(commerceCode, apiKey, IntegrationType.LIVE);
-  }
-
-  public static void configureForTesting() {
-    configureForIntegration(
-      IntegrationCommerceCodes.WEBPAY_PLUS,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  public static void configureForTestingDeferred() {
-    configureForIntegration(
-      IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  public static void configureForTestingMall() {
-    configureForIntegration(
-      IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  public static void configureForTestingMallDeferred() {
-    configureForIntegration(
-      IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
-      IntegrationApiKeys.WEBPAY
-    );
-  }
-
-  public static void configureForMock() {
-    options =
-      new WebpayOptions(
-        IntegrationCommerceCodes.WEBPAY_PLUS,
-        IntegrationApiKeys.WEBPAY,
-        IntegrationType.SERVER_MOCK
-      );
-  }
 }

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayTransaction.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayTransaction.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 abstract class WebpayTransaction extends BaseTransaction {
 
-    public WebpayTransaction(Options options){
+    protected WebpayTransaction(Options options){
         super(options);
     }
 

--- a/src/main/java/cl/transbank/webpay/webpayplus/WebpayTransaction.java
+++ b/src/main/java/cl/transbank/webpay/webpayplus/WebpayTransaction.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 abstract class WebpayTransaction extends BaseTransaction {
 
     public WebpayTransaction(Options options){
-        this.options = options;
+        super(options);
     }
 
     public WebpayPlusTransactionCreateResponse create(String buyOrder, String sessionId, double amount, String returnUrl) throws IOException, TransactionCreateException {

--- a/src/test/java/webpayplus/OneclickMallDeferredTest.java
+++ b/src/test/java/webpayplus/OneclickMallDeferredTest.java
@@ -91,28 +91,28 @@ public class OneclickMallDeferredTest extends TestBase {
     public void finish() throws IOException, InscriptionFinishException {
         String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
 
-        byte responseCode = 0;
-        String authorizationCode = "1213";
+        byte responseCode3 = 0;
+        String authorizationCode3 = "1213";
         String cardType = "Visa";
-        String cardNumber = "XXXXXXXXXXXX6623";
+        String cardNumber3 = "XXXXXXXXXXXX6623";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("response_code", responseCode);
+        mapResponse.put("response_code", responseCode3);
         mapResponse.put("tbk_user", tbkUser);
-        mapResponse.put("authorization_code", authorizationCode);
+        mapResponse.put("authorization_code", authorizationCode3);
         mapResponse.put("card_type", cardType);
-        mapResponse.put("card_number", cardNumber);
+        mapResponse.put("card_number", cardNumber3);
 
         Gson gson = new GsonBuilder().create();
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
         final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
-        assertEquals(response.getResponseCode(), responseCode);
+        assertEquals(response.getResponseCode(), responseCode3);
         assertEquals(response.getTbkUser(), tbkUser);
-        assertEquals(response.getAuthorizationCode(), authorizationCode);
+        assertEquals(response.getAuthorizationCode(), authorizationCode3);
         assertEquals(response.getCardType(), cardType);
-        assertEquals(response.getCardNumber(), cardNumber);
+        assertEquals(response.getCardNumber(), cardNumber3);
 
     }
 
@@ -263,13 +263,13 @@ public class OneclickMallDeferredTest extends TestBase {
     public void capture() throws IOException, TransactionCaptureException {
         String url = String.format("/%s/transactions/capture",apiUrl);
 
-        String authorizationCode = "138248";
-        String authorizationDate = "2021-08-01T03:17:42.785Z";
+        String authorizationCode3 = "138248";
+        String authorizationDate3 = "2021-08-01T03:17:42.785Z";
         double capturedAmount = 1000.0;
         byte responseCode = 0;
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("authorization_code", authorizationCode);
-        mapResponse.put("authorization_date", authorizationDate);
+        mapResponse.put("authorization_code", authorizationCode3);
+        mapResponse.put("authorization_date", authorizationDate3);
         mapResponse.put("captured_amount", capturedAmount);
         mapResponse.put("response_code", responseCode);
 
@@ -280,9 +280,9 @@ public class OneclickMallDeferredTest extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(option)).capture(childCommerceCode, childBuyOrder, authorizationCode, amount);
-        assertEquals(response.getAuthorizationCode(), authorizationCode);
-        assertEquals(response.getAuthorizationDate(), authorizationDate);
+        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(option)).capture(childCommerceCode, childBuyOrder, authorizationCode3, amount);
+        assertEquals(response.getAuthorizationCode(), authorizationCode3);
+        assertEquals(response.getAuthorizationDate(), authorizationDate3);
         assertEquals(response.getCapturedAmount(), capturedAmount);
         assertEquals(response.getResponseCode(), responseCode);
     }

--- a/src/test/java/webpayplus/OneclickMallDeferredTest.java
+++ b/src/test/java/webpayplus/OneclickMallDeferredTest.java
@@ -287,18 +287,4 @@ public class OneclickMallDeferredTest extends TestBase {
         assertEquals(response.getResponseCode(), responseCode);
     }
 
-    //{"username":"goncafa","tbk_user":"aaaaaaaaaaaaa-bbbbbbbb-cccccc"}
-    /*
-    @Test
-    public void delete() throws IOException, InscriptionDeleteException {
-        Oneclick.setIntegrationType(IntegrationType.SERVER_MOCK);
-        String url = "/rswebpaytransaction/api/oneclick/v1.0/inscriptions";
-
-        //String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
-        Map<String, Object> mapResponse = new HashMap<>();
-        Gson gson = new GsonBuilder().create();
-        setResponse(url, gson.toJson(mapResponse));
-        Oneclick.MallDeferredInscription.delete(username, tbkUser);
-
-    }*/
 }

--- a/src/test/java/webpayplus/OneclickMallDeferredTest.java
+++ b/src/test/java/webpayplus/OneclickMallDeferredTest.java
@@ -24,33 +24,37 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 public class OneclickMallDeferredTest extends TestBase {
 
-    private static String API_URL = ApiConstants.ONECLICK_ENDPOINT;
-    private static Options OPTION = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+    private static String apiUrl = ApiConstants.ONECLICK_ENDPOINT;
+    private static Options option = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
-    private static String USERNAME = "goncafa";
-    private static String EMAIL = "gonzalo.castillo@continuum.cl";
-    private static String TBK_USER = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
-    private static String CARD_NUMBER = "6623";
-    private static String TRANSACTION_DATE = "2021-08-01T05:30:06.557Z";
-    private static String ACCOUNTING_DATE = "0801";
-    private static String BUY_ORDER = "724900565";
-    private static double AMOUNT_1 = 1000d;
-    private static String STATUS_1 = "AUTHORIZED";
-    private static String AUTHORIZATION_CODE_1 = "1213";
-    private static String PAYMENT_TYPE_CODE_1 = "VN";
-    private static byte INSTALLMENTS_NUMBER_1 = 0;
-    private static String COMMERCE_CODE_1 = "597055555542";
-    private static String BUY_ORDER_1 = "2019439134";
-    private static byte RESPONSE_CODE_1 = 0;
-    private static double AMOUNT_2 = 1000d;
-    private static String STATUS_2 = "AUTHORIZED";
-    private static String AUTHORIZATION_CODE_2 = "1213";
-    private static String PAYMENT_TYPE_CODE_2 = "VN";
-    private static byte INSTALLMENTS_NUMBER_2 = 0;
-    private static String COMMERCE_CODE_2 = "597055555543";
-    private static String BUY_ORDER_2 = "353345213";
-    private static byte RESPONSE_CODE_2 = 0;
-    private static String TEST_TOKEN = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static String username = "goncafa";
+    private static String email = "gonzalo.castillo@continuum.cl";
+    private static String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
+
+    private static String cardNumber = "6623";
+    private static String transactionDate = "2021-08-01T05:30:06.557Z";
+    private static String accountingDate = "0801";
+    private static String buyOrder = "724900565";
+
+    private static double amount1 = 1000d;
+    private static String status1 = "AUTHORIZED";
+    private static String authorizationCode1 = "1213";
+    private static String paymentTypeCode1 = "VN";
+    private static byte installmentsNumber1 = 0;
+    private static String commerceCode1 = "597055555542";
+    private static String buyOrder1 = "2019439134";
+    private static byte responseCode1 = 0;
+
+    private static double amount2 = 1000d;
+    private static String status2 = "AUTHORIZED";
+    private static String authorizationCode2 = "1213";
+    private static String paymentTypeCode2 = "VN";
+    private static byte installmentsNumber2 = 0;
+    private static String commerceCode2 = "597055555543";
+    private static String buyOrder2 = "353345213";
+    private static byte responseCode2 = 0;
+
+    private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
     public static void startProxy() {
@@ -64,11 +68,11 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void start() throws IOException, InscriptionStartException {
-        String url = String.format("/%s/inscriptions",API_URL);
+        String url = String.format("/%s/inscriptions",apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/bp_multicode_inscription.cgi";
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put(ApiConstants.TOKEN_TEXT, TEST_TOKEN);
+        mapResponse.put(ApiConstants.TOKEN_TEXT, testToken);
         mapResponse.put("url_webpay", urlResponse);
 
         Gson gson = new GsonBuilder().create();
@@ -77,15 +81,15 @@ public class OneclickMallDeferredTest extends TestBase {
 
         String returnUrl = "http://localhost:8081/oneclick-mall/finish";
 
-        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(OPTION)).start(USERNAME, EMAIL, returnUrl);
-        assertEquals(response.getToken(), TEST_TOKEN);
+        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(option)).start(username, email, returnUrl);
+        assertEquals(response.getToken(), testToken);
         assertEquals(response.getUrlWebpay(), urlResponse);
     }
 
 
     @Test
     public void finish() throws IOException, InscriptionFinishException {
-        String url = String.format("/%s/inscriptions/%s", API_URL, TEST_TOKEN);
+        String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
 
         byte responseCode = 0;
         String authorizationCode = "1213";
@@ -94,7 +98,7 @@ public class OneclickMallDeferredTest extends TestBase {
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
         mapResponse.put("response_code", responseCode);
-        mapResponse.put("tbk_user", TBK_USER);
+        mapResponse.put("tbk_user", tbkUser);
         mapResponse.put("authorization_code", authorizationCode);
         mapResponse.put("card_type", cardType);
         mapResponse.put("card_number", cardNumber);
@@ -103,9 +107,9 @@ public class OneclickMallDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(OPTION)).finish(TEST_TOKEN);
+        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
         assertEquals(response.getResponseCode(), responseCode);
-        assertEquals(response.getTbkUser(), TBK_USER);
+        assertEquals(response.getTbkUser(), tbkUser);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getCardType(), cardType);
         assertEquals(response.getCardNumber(), cardNumber);
@@ -116,34 +120,34 @@ public class OneclickMallDeferredTest extends TestBase {
      private Map<String, Object> generateAutorizeJsonResponse(){
 
         Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
-        mapResponseCardDetail.put("card_number", CARD_NUMBER);
+        mapResponseCardDetail.put("card_number", cardNumber);
 
         Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
-        mapResponseDetail1.put("amount", AMOUNT_1);
-        mapResponseDetail1.put("status", STATUS_1);
-        mapResponseDetail1.put("authorization_code", AUTHORIZATION_CODE_1);
-        mapResponseDetail1.put("payment_type_code", PAYMENT_TYPE_CODE_1);
-        mapResponseDetail1.put("response_code", RESPONSE_CODE_1);
-        mapResponseDetail1.put("installments_number", INSTALLMENTS_NUMBER_1);
-        mapResponseDetail1.put("commerce_code", COMMERCE_CODE_1);
-        mapResponseDetail1.put("buy_order", BUY_ORDER_1);
+        mapResponseDetail1.put("amount", amount1);
+        mapResponseDetail1.put("status", status1);
+        mapResponseDetail1.put("authorization_code", authorizationCode1);
+        mapResponseDetail1.put("payment_type_code", paymentTypeCode1);
+        mapResponseDetail1.put("response_code", responseCode1);
+        mapResponseDetail1.put("installments_number", installmentsNumber1);
+        mapResponseDetail1.put("commerce_code", commerceCode1);
+        mapResponseDetail1.put("buy_order", buyOrder1);
 
         Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
-        mapResponseDetail2.put("amount", AMOUNT_2);
-        mapResponseDetail2.put("status", STATUS_2);
-        mapResponseDetail2.put("authorization_code", AUTHORIZATION_CODE_2);
-        mapResponseDetail2.put("payment_type_code", PAYMENT_TYPE_CODE_2);
-        mapResponseDetail2.put("response_code", RESPONSE_CODE_2);
-        mapResponseDetail2.put("installments_number", INSTALLMENTS_NUMBER_2);
-        mapResponseDetail2.put("commerce_code", COMMERCE_CODE_2);
-        mapResponseDetail2.put("buy_order", BUY_ORDER_2);
+        mapResponseDetail2.put("amount", amount2);
+        mapResponseDetail2.put("status", status2);
+        mapResponseDetail2.put("authorization_code", authorizationCode2);
+        mapResponseDetail2.put("payment_type_code", paymentTypeCode2);
+        mapResponseDetail2.put("response_code", responseCode2);
+        mapResponseDetail2.put("installments_number", installmentsNumber2);
+        mapResponseDetail2.put("commerce_code", commerceCode2);
+        mapResponseDetail2.put("buy_order", buyOrder2);
 
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("buy_order", BUY_ORDER);
+        mapResponse.put("buy_order", buyOrder);
         mapResponse.put("card_detail", mapResponseCardDetail);
-        mapResponse.put("accounting_date", ACCOUNTING_DATE);
-        mapResponse.put("transaction_date", TRANSACTION_DATE);
+        mapResponse.put("accounting_date", accountingDate);
+        mapResponse.put("transaction_date", transactionDate);
         //details
         List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
         lstDetail.add(mapResponseDetail1);
@@ -155,7 +159,7 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void authorize() throws IOException, TransactionAuthorizeException {
-        String url = String.format("/%s/transactions",API_URL);
+        String url = String.format("/%s/transactions",apiUrl);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
@@ -171,38 +175,38 @@ public class OneclickMallDeferredTest extends TestBase {
         byte installmentsNumberMallTwo = 1;
 
         MallTransactionCreateDetails details = MallTransactionCreateDetails.build()
-                .add(amountMallOne, COMMERCE_CODE_1, buyOrderMallOne, installmentsNumberMallOne)
-                .add(amountMallTwo, COMMERCE_CODE_2, buyOrderMallTwo, installmentsNumberMallTwo);
+                .add(amountMallOne, commerceCode1, buyOrderMallOne, installmentsNumberMallOne)
+                .add(amountMallTwo, commerceCode2, buyOrderMallTwo, installmentsNumberMallTwo);
 
-        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(OPTION)).authorize(USERNAME, tbkUserReq, buyOrderReq, details);
+        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(option)).authorize(username, tbkUserReq, buyOrderReq, details);
 
-        assertEquals(response.getBuyOrder(), BUY_ORDER);
-        assertEquals(response.getCardDetail().getCardNumber(), CARD_NUMBER);
-        assertEquals(response.getAccountingDate(), ACCOUNTING_DATE);
-        assertEquals(response.getTransactionDate(), TRANSACTION_DATE);
+        assertEquals(response.getBuyOrder(), buyOrder);
+        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
+        assertEquals(response.getAccountingDate(), accountingDate);
+        assertEquals(response.getTransactionDate(), transactionDate);
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), AMOUNT_1);
-        assertEquals(response.getDetails().get(0).getStatus(), STATUS_1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), AUTHORIZATION_CODE_1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), PAYMENT_TYPE_CODE_1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), RESPONSE_CODE_1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), INSTALLMENTS_NUMBER_1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), COMMERCE_CODE_1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), BUY_ORDER_1);
+        assertEquals(response.getDetails().get(0).getAmount(), amount1);
+        assertEquals(response.getDetails().get(0).getStatus(), status1);
+        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
+        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
+        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
+        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
+        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
+        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), AMOUNT_2);
-        assertEquals(response.getDetails().get(1).getStatus(), STATUS_2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), AUTHORIZATION_CODE_2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), PAYMENT_TYPE_CODE_2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), RESPONSE_CODE_2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), INSTALLMENTS_NUMBER_2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), COMMERCE_CODE_2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), BUY_ORDER_2);
+        assertEquals(response.getDetails().get(1).getAmount(), amount2);
+        assertEquals(response.getDetails().get(1).getStatus(), status2);
+        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
+        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
+        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
+        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
+        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
+        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
     }
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        String url = String.format("/%s/transactions/%s/refunds", API_URL, BUY_ORDER);
+        String url = String.format("/%s/transactions/%s/refunds", apiUrl, buyOrder);
 
         String type = "REVERSED";
 
@@ -216,48 +220,48 @@ public class OneclickMallDeferredTest extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(OPTION)).refund(BUY_ORDER, childCommerceCode, childBuyOrder, amount);
+        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(option)).refund(buyOrder, childCommerceCode, childBuyOrder, amount);
 
         assertEquals(response.getType(), type);
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        String url = String.format("/%s/transactions/%s", API_URL, BUY_ORDER);
+        String url = String.format("/%s/transactions/%s", apiUrl, buyOrder);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(OPTION)).status(BUY_ORDER);
+        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(buyOrder);
 
-        assertEquals(response.getBuyOrder(), BUY_ORDER);
-        assertEquals(response.getCardDetail().getCardNumber(), CARD_NUMBER);
-        assertEquals(response.getAccountingDate(), ACCOUNTING_DATE);
-        assertEquals(response.getTransactionDate(), TRANSACTION_DATE);
+        assertEquals(response.getBuyOrder(), buyOrder);
+        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
+        assertEquals(response.getAccountingDate(), accountingDate);
+        assertEquals(response.getTransactionDate(), transactionDate);
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), AMOUNT_1);
-        assertEquals(response.getDetails().get(0).getStatus(), STATUS_1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), AUTHORIZATION_CODE_1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), PAYMENT_TYPE_CODE_1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), RESPONSE_CODE_1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), INSTALLMENTS_NUMBER_1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), COMMERCE_CODE_1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), BUY_ORDER_1);
+        assertEquals(response.getDetails().get(0).getAmount(), amount1);
+        assertEquals(response.getDetails().get(0).getStatus(), status1);
+        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
+        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
+        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
+        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
+        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
+        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), AMOUNT_2);
-        assertEquals(response.getDetails().get(1).getStatus(), STATUS_2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), AUTHORIZATION_CODE_2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), PAYMENT_TYPE_CODE_2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), RESPONSE_CODE_2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), INSTALLMENTS_NUMBER_2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), COMMERCE_CODE_2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), BUY_ORDER_2);
+        assertEquals(response.getDetails().get(1).getAmount(), amount2);
+        assertEquals(response.getDetails().get(1).getStatus(), status2);
+        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
+        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
+        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
+        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
+        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
+        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
     }
 
     @Test
     public void capture() throws IOException, TransactionCaptureException {
-        String url = String.format("/%s/transactions/capture",API_URL);
+        String url = String.format("/%s/transactions/capture",apiUrl);
 
         String authorizationCode = "138248";
         String authorizationDate = "2021-08-01T03:17:42.785Z";
@@ -276,7 +280,7 @@ public class OneclickMallDeferredTest extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(OPTION)).capture(childCommerceCode, childBuyOrder, authorizationCode, amount);
+        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(option)).capture(childCommerceCode, childBuyOrder, authorizationCode, amount);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getAuthorizationDate(), authorizationDate);
         assertEquals(response.getCapturedAmount(), capturedAmount);

--- a/src/test/java/webpayplus/OneclickMallDeferredTest.java
+++ b/src/test/java/webpayplus/OneclickMallDeferredTest.java
@@ -1,6 +1,11 @@
 package webpayplus;
 
 import cl.transbank.common.ApiConstants;
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.common.IntegrationType;
+import cl.transbank.model.Options;
+import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.*;
 import cl.transbank.webpay.oneclick.Oneclick;
 import cl.transbank.webpay.oneclick.model.*;
@@ -20,7 +25,8 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 public class OneclickMallDeferredTest extends TestBase {
 
     private static String apiUrl = ApiConstants.ONECLICK_ENDPOINT;
-
+    private static Options option = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+            IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
     private static String username = "goncafa";
     private static String email = "gonzalo.castillo@continuum.cl";
     private static String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
@@ -62,7 +68,6 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void start() throws IOException, InscriptionStartException {
-        Oneclick.configureForMock();
         String url = String.format("/%s/inscriptions",apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/bp_multicode_inscription.cgi";
@@ -76,7 +81,7 @@ public class OneclickMallDeferredTest extends TestBase {
 
         String returnUrl = "http://localhost:8081/oneclick-mall/finish";
 
-        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription()).start(username, email, returnUrl);
+        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(option)).start(username, email, returnUrl);
         assertEquals(response.getToken(), testToken);
         assertEquals(response.getUrlWebpay(), urlResponse);
     }
@@ -84,7 +89,6 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void finish() throws IOException, InscriptionFinishException {
-        Oneclick.configureForMock();
         String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
 
         byte responseCode = 0;
@@ -103,7 +107,7 @@ public class OneclickMallDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription()).finish(testToken);
+        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
         assertEquals(response.getResponseCode(), responseCode);
         assertEquals(response.getTbkUser(), tbkUser);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
@@ -155,7 +159,6 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void authorize() throws IOException, TransactionAuthorizeException {
-        Oneclick.configureForMock();
         String url = String.format("/%s/transactions",apiUrl);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
@@ -175,7 +178,7 @@ public class OneclickMallDeferredTest extends TestBase {
                 .add(amountMallOne, commerceCode1, buyOrderMallOne, installmentsNumberMallOne)
                 .add(amountMallTwo, commerceCode2, buyOrderMallTwo, installmentsNumberMallTwo);
 
-        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction()).authorize(username, tbkUserReq, buyOrderReq, details);
+        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(option)).authorize(username, tbkUserReq, buyOrderReq, details);
 
         assertEquals(response.getBuyOrder(), buyOrder);
         assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
@@ -203,7 +206,6 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        Oneclick.configureForMock();
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, buyOrder);
 
         String type = "REVERSED";
@@ -218,21 +220,20 @@ public class OneclickMallDeferredTest extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction()).refund(buyOrder, childCommerceCode, childBuyOrder, amount);
+        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(option)).refund(buyOrder, childCommerceCode, childBuyOrder, amount);
 
         assertEquals(response.getType(), type);
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        Oneclick.configureForMock();
         String url = String.format("/%s/transactions/%s", apiUrl, buyOrder);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction()).status(buyOrder);
+        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(buyOrder);
 
         assertEquals(response.getBuyOrder(), buyOrder);
         assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
@@ -260,7 +261,6 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void capture() throws IOException, TransactionCaptureException {
-        Oneclick.configureForMock();
         String url = String.format("/%s/transactions/capture",apiUrl);
 
         String authorizationCode = "138248";
@@ -280,7 +280,7 @@ public class OneclickMallDeferredTest extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction()).capture(childCommerceCode, childBuyOrder, authorizationCode, amount);
+        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(option)).capture(childCommerceCode, childBuyOrder, authorizationCode, amount);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getAuthorizationDate(), authorizationDate);
         assertEquals(response.getCapturedAmount(), capturedAmount);

--- a/src/test/java/webpayplus/OneclickMallDeferredTest.java
+++ b/src/test/java/webpayplus/OneclickMallDeferredTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 
-public class OneclickMallDeferredTest extends TestBase {
+public class OneclickMallDeferredTest extends OneclickMallTestBase {
 
     private static String apiUrl = ApiConstants.ONECLICK_ENDPOINT;
     private static Options option = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
@@ -30,30 +30,8 @@ public class OneclickMallDeferredTest extends TestBase {
     private static String username = "goncafa";
     private static String email = "gonzalo.castillo@continuum.cl";
     private static String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
-
-    private static String cardNumber = "6623";
-    private static String transactionDate = "2021-08-01T05:30:06.557Z";
-    private static String accountingDate = "0801";
-    private static String buyOrder = "724900565";
-
-    private static double amount1 = 1000d;
-    private static String status1 = "AUTHORIZED";
-    private static String authorizationCode1 = "1213";
-    private static String paymentTypeCode1 = "VN";
-    private static byte installmentsNumber1 = 0;
     private static String commerceCode1 = "597055555542";
-    private static String buyOrder1 = "2019439134";
-    private static byte responseCode1 = 0;
-
-    private static double amount2 = 1000d;
-    private static String status2 = "AUTHORIZED";
-    private static String authorizationCode2 = "1213";
-    private static String paymentTypeCode2 = "VN";
-    private static byte installmentsNumber2 = 0;
     private static String commerceCode2 = "597055555543";
-    private static String buyOrder2 = "353345213";
-    private static byte responseCode2 = 0;
-
     private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
@@ -86,84 +64,39 @@ public class OneclickMallDeferredTest extends TestBase {
         assertEquals(response.getUrlWebpay(), urlResponse);
     }
 
-
     @Test
     public void finish() throws IOException, InscriptionFinishException {
         String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
 
-        byte responseCode3 = 0;
-        String authorizationCode3 = "1213";
+        byte responseCode = 0;
+        String authorizationCode = "1213";
         String cardType = "Visa";
-        String cardNumber3 = "XXXXXXXXXXXX6623";
+        String cardNumber = "XXXXXXXXXXXX6623";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("response_code", responseCode3);
+        mapResponse.put("response_code", responseCode);
         mapResponse.put("tbk_user", tbkUser);
-        mapResponse.put("authorization_code", authorizationCode3);
+        mapResponse.put("authorization_code", authorizationCode);
         mapResponse.put("card_type", cardType);
-        mapResponse.put("card_number", cardNumber3);
+        mapResponse.put("card_number", cardNumber);
 
         Gson gson = new GsonBuilder().create();
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
         final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
-        assertEquals(response.getResponseCode(), responseCode3);
+        assertEquals(response.getResponseCode(), responseCode);
         assertEquals(response.getTbkUser(), tbkUser);
-        assertEquals(response.getAuthorizationCode(), authorizationCode3);
+        assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getCardType(), cardType);
-        assertEquals(response.getCardNumber(), cardNumber3);
+        assertEquals(response.getCardNumber(), cardNumber);
 
     }
-
-
-     private Map<String, Object> generateAutorizeJsonResponse(){
-
-        Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
-        mapResponseCardDetail.put("card_number", cardNumber);
-
-        Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
-        mapResponseDetail1.put("amount", amount1);
-        mapResponseDetail1.put("status", status1);
-        mapResponseDetail1.put("authorization_code", authorizationCode1);
-        mapResponseDetail1.put("payment_type_code", paymentTypeCode1);
-        mapResponseDetail1.put("response_code", responseCode1);
-        mapResponseDetail1.put("installments_number", installmentsNumber1);
-        mapResponseDetail1.put("commerce_code", commerceCode1);
-        mapResponseDetail1.put("buy_order", buyOrder1);
-
-        Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
-        mapResponseDetail2.put("amount", amount2);
-        mapResponseDetail2.put("status", status2);
-        mapResponseDetail2.put("authorization_code", authorizationCode2);
-        mapResponseDetail2.put("payment_type_code", paymentTypeCode2);
-        mapResponseDetail2.put("response_code", responseCode2);
-        mapResponseDetail2.put("installments_number", installmentsNumber2);
-        mapResponseDetail2.put("commerce_code", commerceCode2);
-        mapResponseDetail2.put("buy_order", buyOrder2);
-
-
-        Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("buy_order", buyOrder);
-        mapResponse.put("card_detail", mapResponseCardDetail);
-        mapResponse.put("accounting_date", accountingDate);
-        mapResponse.put("transaction_date", transactionDate);
-        //details
-        List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
-        lstDetail.add(mapResponseDetail1);
-        lstDetail.add(mapResponseDetail2);
-        mapResponse.put("details", lstDetail);
-
-        return mapResponse;
-    }
-
     @Test
     public void authorize() throws IOException, TransactionAuthorizeException {
+        OneclickMallTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions",apiUrl);
-
-        Map<String, Object> mapResponse = generateAutorizeJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponsePost(url, gson.toJson(mapResponse));
+        setResponsePost(url, generateJsonResponse());
 
         String tbkUserReq = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
         String buyOrderReq = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
@@ -180,32 +113,37 @@ public class OneclickMallDeferredTest extends TestBase {
 
         final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(option)).authorize(username, tbkUserReq, buyOrderReq, details);
 
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getBuyOrder(), expectedResponse.getBuyOrder());
+        assertEquals(response.getCardDetail().getCardNumber(), expectedResponse.getCardDetail().getCardNumber());
+        assertEquals(response.getAccountingDate(), expectedResponse.getAccountingDate());
+        assertEquals(response.getTransactionDate(), expectedResponse.getTransactionDate());
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        OneclickMallTransactionStatusResponse.Detail expectedDetail1 = expectedResponse.getDetails().get(0);
+        OneclickMallTransactionAuthorizeResponse.Detail detail1 = response.getDetails().get(0);
+        assertEquals(detail1.getAmount(), expectedDetail1.getAmount());
+        assertEquals(detail1.getStatus(), expectedDetail1.getStatus());
+        assertEquals(detail1.getAuthorizationCode(), expectedDetail1.getAuthorizationCode());
+        assertEquals(detail1.getPaymentTypeCode(), expectedDetail1.getPaymentTypeCode());
+        assertEquals(detail1.getResponseCode(), expectedDetail1.getResponseCode());
+        assertEquals(detail1.getInstallmentsNumber(), expectedDetail1.getInstallmentsNumber());
+        assertEquals(detail1.getCommerceCode(), expectedDetail1.getCommerceCode());
+        assertEquals(detail1.getBuyOrder(), expectedDetail1.getBuyOrder());
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        OneclickMallTransactionStatusResponse.Detail expectedDetail2 = expectedResponse.getDetails().get(1);
+        OneclickMallTransactionAuthorizeResponse.Detail detail2 = response.getDetails().get(1);
+        assertEquals(detail2.getAmount(), expectedDetail2.getAmount());
+        assertEquals(detail2.getStatus(), expectedDetail2.getStatus());
+        assertEquals(detail2.getAuthorizationCode(), expectedDetail2.getAuthorizationCode());
+        assertEquals(detail2.getPaymentTypeCode(), expectedDetail2.getPaymentTypeCode());
+        assertEquals(detail2.getResponseCode(), expectedDetail2.getResponseCode());
+        assertEquals(detail2.getInstallmentsNumber(), expectedDetail2.getInstallmentsNumber());
+        assertEquals(detail2.getCommerceCode(), expectedDetail2.getCommerceCode());
+        assertEquals(detail2.getBuyOrder(), expectedDetail2.getBuyOrder());
     }
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
+        String buyOrder = "1643997337";
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, buyOrder);
 
         String type = "REVERSED";
@@ -227,62 +165,63 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        String url = String.format("/%s/transactions/%s", apiUrl, buyOrder);
+        OneclickMallTransactionStatusResponse expectedResponse = generateStatusResponse();
+        String url = String.format("/%s/transactions/%s", apiUrl, expectedResponse.getBuyOrder());
+        setResponseGet(url, generateJsonResponse());
 
-        Map<String, Object> mapResponse = generateAutorizeJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponseGet(url, gson.toJson(mapResponse));
+        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(expectedResponse.getBuyOrder());
 
-        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(buyOrder);
-
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getBuyOrder(), expectedResponse.getBuyOrder());
+        assertEquals(response.getCardDetail().getCardNumber(), expectedResponse.getCardDetail().getCardNumber());
+        assertEquals(response.getAccountingDate(), expectedResponse.getAccountingDate());
+        assertEquals(response.getTransactionDate(), expectedResponse.getTransactionDate());
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        OneclickMallTransactionStatusResponse.Detail expectedDetail1 = expectedResponse.getDetails().get(0);
+        OneclickMallTransactionStatusResponse.Detail detail1 = response.getDetails().get(0);
+        assertEquals(detail1.getAmount(), expectedDetail1.getAmount());
+        assertEquals(detail1.getStatus(), expectedDetail1.getStatus());
+        assertEquals(detail1.getAuthorizationCode(), expectedDetail1.getAuthorizationCode());
+        assertEquals(detail1.getPaymentTypeCode(), expectedDetail1.getPaymentTypeCode());
+        assertEquals(detail1.getResponseCode(), expectedDetail1.getResponseCode());
+        assertEquals(detail1.getInstallmentsNumber(), expectedDetail1.getInstallmentsNumber());
+        assertEquals(detail1.getCommerceCode(), expectedDetail1.getCommerceCode());
+        assertEquals(detail1.getBuyOrder(), expectedDetail1.getBuyOrder());
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        OneclickMallTransactionStatusResponse.Detail expectedDetail2 = expectedResponse.getDetails().get(1);
+        OneclickMallTransactionStatusResponse.Detail detail2 = response.getDetails().get(1);
+        assertEquals(detail2.getAmount(), expectedDetail2.getAmount());
+        assertEquals(detail2.getStatus(), expectedDetail2.getStatus());
+        assertEquals(detail2.getAuthorizationCode(), expectedDetail2.getAuthorizationCode());
+        assertEquals(detail2.getPaymentTypeCode(), expectedDetail2.getPaymentTypeCode());
+        assertEquals(detail2.getResponseCode(), expectedDetail2.getResponseCode());
+        assertEquals(detail2.getInstallmentsNumber(), expectedDetail2.getInstallmentsNumber());
+        assertEquals(detail2.getCommerceCode(), expectedDetail2.getCommerceCode());
+        assertEquals(detail2.getBuyOrder(), expectedDetail2.getBuyOrder());
     }
 
     @Test
     public void capture() throws IOException, TransactionCaptureException {
         String url = String.format("/%s/transactions/capture",apiUrl);
 
-        String authorizationCode3 = "138248";
-        String authorizationDate3 = "2021-08-01T03:17:42.785Z";
+        String authorizationCode = "138248";
+        String authorizationDate = "2021-08-01T03:17:42.785Z";
         double capturedAmount = 1000.0;
         byte responseCode = 0;
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("authorization_code", authorizationCode3);
-        mapResponse.put("authorization_date", authorizationDate3);
+        mapResponse.put("authorization_code", authorizationCode);
+        mapResponse.put("authorization_date", authorizationDate);
         mapResponse.put("captured_amount", capturedAmount);
         mapResponse.put("response_code", responseCode);
 
         Gson gson = new GsonBuilder().create();
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
-
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
-        double amount = 1000d;
-        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(option)).capture(childCommerceCode, childBuyOrder, authorizationCode3, amount);
-        assertEquals(response.getAuthorizationCode(), authorizationCode3);
-        assertEquals(response.getAuthorizationDate(), authorizationDate3);
+
+        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(option)).capture(childCommerceCode, childBuyOrder, authorizationCode, capturedAmount);
+        assertEquals(response.getAuthorizationCode(), authorizationCode);
+        assertEquals(response.getAuthorizationDate(), authorizationDate);
         assertEquals(response.getCapturedAmount(), capturedAmount);
         assertEquals(response.getResponseCode(), responseCode);
     }

--- a/src/test/java/webpayplus/OneclickMallDeferredTest.java
+++ b/src/test/java/webpayplus/OneclickMallDeferredTest.java
@@ -24,37 +24,33 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 public class OneclickMallDeferredTest extends TestBase {
 
-    private static String apiUrl = ApiConstants.ONECLICK_ENDPOINT;
-    private static Options option = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
+    private static String API_URL = ApiConstants.ONECLICK_ENDPOINT;
+    private static Options OPTION = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL_DEFERRED,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
-    private static String username = "goncafa";
-    private static String email = "gonzalo.castillo@continuum.cl";
-    private static String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
-
-    private static String cardNumber = "6623";
-    private static String transactionDate = "2021-08-01T05:30:06.557Z";
-    private static String accountingDate = "0801";
-    private static String buyOrder = "724900565";
-
-    private static double amount1 = 1000d;
-    private static String status1 = "AUTHORIZED";
-    private static String authorizationCode1 = "1213";
-    private static String paymentTypeCode1 = "VN";
-    private static byte installmentsNumber1 = 0;
-    private static String commerceCode1 = "597055555542";
-    private static String buyOrder1 = "2019439134";
-    private static byte responseCode1 = 0;
-
-    private static double amount2 = 1000d;
-    private static String status2 = "AUTHORIZED";
-    private static String authorizationCode2 = "1213";
-    private static String paymentTypeCode2 = "VN";
-    private static byte installmentsNumber2 = 0;
-    private static String commerceCode2 = "597055555543";
-    private static String buyOrder2 = "353345213";
-    private static byte responseCode2 = 0;
-
-    private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static String USERNAME = "goncafa";
+    private static String EMAIL = "gonzalo.castillo@continuum.cl";
+    private static String TBK_USER = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
+    private static String CARD_NUMBER = "6623";
+    private static String TRANSACTION_DATE = "2021-08-01T05:30:06.557Z";
+    private static String ACCOUNTING_DATE = "0801";
+    private static String BUY_ORDER = "724900565";
+    private static double AMOUNT_1 = 1000d;
+    private static String STATUS_1 = "AUTHORIZED";
+    private static String AUTHORIZATION_CODE_1 = "1213";
+    private static String PAYMENT_TYPE_CODE_1 = "VN";
+    private static byte INSTALLMENTS_NUMBER_1 = 0;
+    private static String COMMERCE_CODE_1 = "597055555542";
+    private static String BUY_ORDER_1 = "2019439134";
+    private static byte RESPONSE_CODE_1 = 0;
+    private static double AMOUNT_2 = 1000d;
+    private static String STATUS_2 = "AUTHORIZED";
+    private static String AUTHORIZATION_CODE_2 = "1213";
+    private static String PAYMENT_TYPE_CODE_2 = "VN";
+    private static byte INSTALLMENTS_NUMBER_2 = 0;
+    private static String COMMERCE_CODE_2 = "597055555543";
+    private static String BUY_ORDER_2 = "353345213";
+    private static byte RESPONSE_CODE_2 = 0;
+    private static String TEST_TOKEN = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
     public static void startProxy() {
@@ -68,11 +64,11 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void start() throws IOException, InscriptionStartException {
-        String url = String.format("/%s/inscriptions",apiUrl);
+        String url = String.format("/%s/inscriptions",API_URL);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/bp_multicode_inscription.cgi";
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put(ApiConstants.TOKEN_TEXT, testToken);
+        mapResponse.put(ApiConstants.TOKEN_TEXT, TEST_TOKEN);
         mapResponse.put("url_webpay", urlResponse);
 
         Gson gson = new GsonBuilder().create();
@@ -81,15 +77,15 @@ public class OneclickMallDeferredTest extends TestBase {
 
         String returnUrl = "http://localhost:8081/oneclick-mall/finish";
 
-        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(option)).start(username, email, returnUrl);
-        assertEquals(response.getToken(), testToken);
+        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(OPTION)).start(USERNAME, EMAIL, returnUrl);
+        assertEquals(response.getToken(), TEST_TOKEN);
         assertEquals(response.getUrlWebpay(), urlResponse);
     }
 
 
     @Test
     public void finish() throws IOException, InscriptionFinishException {
-        String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
+        String url = String.format("/%s/inscriptions/%s", API_URL, TEST_TOKEN);
 
         byte responseCode = 0;
         String authorizationCode = "1213";
@@ -98,7 +94,7 @@ public class OneclickMallDeferredTest extends TestBase {
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
         mapResponse.put("response_code", responseCode);
-        mapResponse.put("tbk_user", tbkUser);
+        mapResponse.put("tbk_user", TBK_USER);
         mapResponse.put("authorization_code", authorizationCode);
         mapResponse.put("card_type", cardType);
         mapResponse.put("card_number", cardNumber);
@@ -107,9 +103,9 @@ public class OneclickMallDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
+        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(OPTION)).finish(TEST_TOKEN);
         assertEquals(response.getResponseCode(), responseCode);
-        assertEquals(response.getTbkUser(), tbkUser);
+        assertEquals(response.getTbkUser(), TBK_USER);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getCardType(), cardType);
         assertEquals(response.getCardNumber(), cardNumber);
@@ -120,34 +116,34 @@ public class OneclickMallDeferredTest extends TestBase {
      private Map<String, Object> generateAutorizeJsonResponse(){
 
         Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
-        mapResponseCardDetail.put("card_number", cardNumber);
+        mapResponseCardDetail.put("card_number", CARD_NUMBER);
 
         Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
-        mapResponseDetail1.put("amount", amount1);
-        mapResponseDetail1.put("status", status1);
-        mapResponseDetail1.put("authorization_code", authorizationCode1);
-        mapResponseDetail1.put("payment_type_code", paymentTypeCode1);
-        mapResponseDetail1.put("response_code", responseCode1);
-        mapResponseDetail1.put("installments_number", installmentsNumber1);
-        mapResponseDetail1.put("commerce_code", commerceCode1);
-        mapResponseDetail1.put("buy_order", buyOrder1);
+        mapResponseDetail1.put("amount", AMOUNT_1);
+        mapResponseDetail1.put("status", STATUS_1);
+        mapResponseDetail1.put("authorization_code", AUTHORIZATION_CODE_1);
+        mapResponseDetail1.put("payment_type_code", PAYMENT_TYPE_CODE_1);
+        mapResponseDetail1.put("response_code", RESPONSE_CODE_1);
+        mapResponseDetail1.put("installments_number", INSTALLMENTS_NUMBER_1);
+        mapResponseDetail1.put("commerce_code", COMMERCE_CODE_1);
+        mapResponseDetail1.put("buy_order", BUY_ORDER_1);
 
         Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
-        mapResponseDetail2.put("amount", amount2);
-        mapResponseDetail2.put("status", status2);
-        mapResponseDetail2.put("authorization_code", authorizationCode2);
-        mapResponseDetail2.put("payment_type_code", paymentTypeCode2);
-        mapResponseDetail2.put("response_code", responseCode2);
-        mapResponseDetail2.put("installments_number", installmentsNumber2);
-        mapResponseDetail2.put("commerce_code", commerceCode2);
-        mapResponseDetail2.put("buy_order", buyOrder2);
+        mapResponseDetail2.put("amount", AMOUNT_2);
+        mapResponseDetail2.put("status", STATUS_2);
+        mapResponseDetail2.put("authorization_code", AUTHORIZATION_CODE_2);
+        mapResponseDetail2.put("payment_type_code", PAYMENT_TYPE_CODE_2);
+        mapResponseDetail2.put("response_code", RESPONSE_CODE_2);
+        mapResponseDetail2.put("installments_number", INSTALLMENTS_NUMBER_2);
+        mapResponseDetail2.put("commerce_code", COMMERCE_CODE_2);
+        mapResponseDetail2.put("buy_order", BUY_ORDER_2);
 
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("buy_order", buyOrder);
+        mapResponse.put("buy_order", BUY_ORDER);
         mapResponse.put("card_detail", mapResponseCardDetail);
-        mapResponse.put("accounting_date", accountingDate);
-        mapResponse.put("transaction_date", transactionDate);
+        mapResponse.put("accounting_date", ACCOUNTING_DATE);
+        mapResponse.put("transaction_date", TRANSACTION_DATE);
         //details
         List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
         lstDetail.add(mapResponseDetail1);
@@ -159,7 +155,7 @@ public class OneclickMallDeferredTest extends TestBase {
 
     @Test
     public void authorize() throws IOException, TransactionAuthorizeException {
-        String url = String.format("/%s/transactions",apiUrl);
+        String url = String.format("/%s/transactions",API_URL);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
@@ -175,38 +171,38 @@ public class OneclickMallDeferredTest extends TestBase {
         byte installmentsNumberMallTwo = 1;
 
         MallTransactionCreateDetails details = MallTransactionCreateDetails.build()
-                .add(amountMallOne, commerceCode1, buyOrderMallOne, installmentsNumberMallOne)
-                .add(amountMallTwo, commerceCode2, buyOrderMallTwo, installmentsNumberMallTwo);
+                .add(amountMallOne, COMMERCE_CODE_1, buyOrderMallOne, installmentsNumberMallOne)
+                .add(amountMallTwo, COMMERCE_CODE_2, buyOrderMallTwo, installmentsNumberMallTwo);
 
-        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(option)).authorize(username, tbkUserReq, buyOrderReq, details);
+        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(OPTION)).authorize(USERNAME, tbkUserReq, buyOrderReq, details);
 
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getBuyOrder(), BUY_ORDER);
+        assertEquals(response.getCardDetail().getCardNumber(), CARD_NUMBER);
+        assertEquals(response.getAccountingDate(), ACCOUNTING_DATE);
+        assertEquals(response.getTransactionDate(), TRANSACTION_DATE);
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        assertEquals(response.getDetails().get(0).getAmount(), AMOUNT_1);
+        assertEquals(response.getDetails().get(0).getStatus(), STATUS_1);
+        assertEquals(response.getDetails().get(0).getAuthorizationCode(), AUTHORIZATION_CODE_1);
+        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), PAYMENT_TYPE_CODE_1);
+        assertEquals(response.getDetails().get(0).getResponseCode(), RESPONSE_CODE_1);
+        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), INSTALLMENTS_NUMBER_1);
+        assertEquals(response.getDetails().get(0).getCommerceCode(), COMMERCE_CODE_1);
+        assertEquals(response.getDetails().get(0).getBuyOrder(), BUY_ORDER_1);
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        assertEquals(response.getDetails().get(1).getAmount(), AMOUNT_2);
+        assertEquals(response.getDetails().get(1).getStatus(), STATUS_2);
+        assertEquals(response.getDetails().get(1).getAuthorizationCode(), AUTHORIZATION_CODE_2);
+        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), PAYMENT_TYPE_CODE_2);
+        assertEquals(response.getDetails().get(1).getResponseCode(), RESPONSE_CODE_2);
+        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), INSTALLMENTS_NUMBER_2);
+        assertEquals(response.getDetails().get(1).getCommerceCode(), COMMERCE_CODE_2);
+        assertEquals(response.getDetails().get(1).getBuyOrder(), BUY_ORDER_2);
     }
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        String url = String.format("/%s/transactions/%s/refunds", apiUrl, buyOrder);
+        String url = String.format("/%s/transactions/%s/refunds", API_URL, BUY_ORDER);
 
         String type = "REVERSED";
 
@@ -220,48 +216,48 @@ public class OneclickMallDeferredTest extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(option)).refund(buyOrder, childCommerceCode, childBuyOrder, amount);
+        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(OPTION)).refund(BUY_ORDER, childCommerceCode, childBuyOrder, amount);
 
         assertEquals(response.getType(), type);
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        String url = String.format("/%s/transactions/%s", apiUrl, buyOrder);
+        String url = String.format("/%s/transactions/%s", API_URL, BUY_ORDER);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(buyOrder);
+        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(OPTION)).status(BUY_ORDER);
 
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getBuyOrder(), BUY_ORDER);
+        assertEquals(response.getCardDetail().getCardNumber(), CARD_NUMBER);
+        assertEquals(response.getAccountingDate(), ACCOUNTING_DATE);
+        assertEquals(response.getTransactionDate(), TRANSACTION_DATE);
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        assertEquals(response.getDetails().get(0).getAmount(), AMOUNT_1);
+        assertEquals(response.getDetails().get(0).getStatus(), STATUS_1);
+        assertEquals(response.getDetails().get(0).getAuthorizationCode(), AUTHORIZATION_CODE_1);
+        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), PAYMENT_TYPE_CODE_1);
+        assertEquals(response.getDetails().get(0).getResponseCode(), RESPONSE_CODE_1);
+        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), INSTALLMENTS_NUMBER_1);
+        assertEquals(response.getDetails().get(0).getCommerceCode(), COMMERCE_CODE_1);
+        assertEquals(response.getDetails().get(0).getBuyOrder(), BUY_ORDER_1);
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        assertEquals(response.getDetails().get(1).getAmount(), AMOUNT_2);
+        assertEquals(response.getDetails().get(1).getStatus(), STATUS_2);
+        assertEquals(response.getDetails().get(1).getAuthorizationCode(), AUTHORIZATION_CODE_2);
+        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), PAYMENT_TYPE_CODE_2);
+        assertEquals(response.getDetails().get(1).getResponseCode(), RESPONSE_CODE_2);
+        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), INSTALLMENTS_NUMBER_2);
+        assertEquals(response.getDetails().get(1).getCommerceCode(), COMMERCE_CODE_2);
+        assertEquals(response.getDetails().get(1).getBuyOrder(), BUY_ORDER_2);
     }
 
     @Test
     public void capture() throws IOException, TransactionCaptureException {
-        String url = String.format("/%s/transactions/capture",apiUrl);
+        String url = String.format("/%s/transactions/capture",API_URL);
 
         String authorizationCode = "138248";
         String authorizationDate = "2021-08-01T03:17:42.785Z";
@@ -280,7 +276,7 @@ public class OneclickMallDeferredTest extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(option)).capture(childCommerceCode, childBuyOrder, authorizationCode, amount);
+        final OneclickMallTransactionCaptureResponse response = (new Oneclick.MallTransaction(OPTION)).capture(childCommerceCode, childBuyOrder, authorizationCode, amount);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getAuthorizationDate(), authorizationDate);
         assertEquals(response.getCapturedAmount(), capturedAmount);

--- a/src/test/java/webpayplus/OneclickMallTest.java
+++ b/src/test/java/webpayplus/OneclickMallTest.java
@@ -24,33 +24,37 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 public class OneclickMallTest  extends TestBase {
 
-    private static String API_URL = ApiConstants.ONECLICK_ENDPOINT;
-    private static Options OPTION = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL,
+    private static String apiUrl = ApiConstants.ONECLICK_ENDPOINT;
+    private static Options option = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
-    private static String USERNAME = "goncafa";
-    private static String EMAIL = "gonzalo.castillo@continuum.cl";
-    private static String TBK_USER = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
-    private static String CARD_NUMBER = "6623";
-    private static String TRANSACTION_DATE = "2021-08-01T05:30:06.557Z";
-    private static String ACCOUNTING_DATE = "0801";
-    private static String BUY_ORDER = "724900565";
-    private static double AMOUNT_1 = 1000d;
-    private static String STATUS_1 = "AUTHORIZED";
-    private static String AUTHORIZATION_CODE_1 = "1213";
-    private static String PAYMENT_TYPE_CODE_1 = "VN";
-    private static byte INSTALLMENTS_NUMBER_1 = 0;
-    private static String COMMERCE_CODE_1 = "597055555542";
-    private static String BUY_ORDER_1 = "2019439134";
-    private static byte RESPONSE_CODE_1 = 0;
-    private static double AMOUNT_2 = 1000d;
-    private static String STATUS_2 = "AUTHORIZED";
-    private static String AUTHORIZATION_CODE_2 = "1213";
-    private static String PAYMENT_TYPE_CODE_2 = "VN";
-    private static byte INSTALLMENTS_NUMBER_2 = 0;
-    private static String COMMERCE_CODE_2 = "597055555543";
-    private static String BUY_ORDER_2 = "353345213";
-    private static byte RESPONSE_CODE_2 = 0;
-    private static String TEST_TOKEN = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static String username = "goncafa";
+    private static String email = "gonzalo.castillo@continuum.cl";
+    private static String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
+
+    private static String cardNumber = "6623";
+    private static String transactionDate = "2021-08-01T05:30:06.557Z";
+    private static String accountingDate = "0801";
+    private static String buyOrder = "724900565";
+
+    private static double amount1 = 1000d;
+    private static String status1 = "AUTHORIZED";
+    private static String authorizationCode1 = "1213";
+    private static String paymentTypeCode1 = "VN";
+    private static byte installmentsNumber1 = 0;
+    private static String commerceCode1 = "597055555542";
+    private static String buyOrder1 = "2019439134";
+    private static byte responseCode1 = 0;
+
+    private static double amount2 = 1000d;
+    private static String status2 = "AUTHORIZED";
+    private static String authorizationCode2 = "1213";
+    private static String paymentTypeCode2 = "VN";
+    private static byte installmentsNumber2 = 0;
+    private static String commerceCode2 = "597055555543";
+    private static String buyOrder2 = "353345213";
+    private static byte responseCode2 = 0;
+
+    private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
     public static void startProxy() {
@@ -64,11 +68,11 @@ public class OneclickMallTest  extends TestBase {
 
     @Test
     public void start() throws IOException, InscriptionStartException {
-        String url = String.format("/%s/inscriptions",API_URL);
+        String url = String.format("/%s/inscriptions",apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/bp_multicode_inscription.cgi";
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put(ApiConstants.TOKEN_TEXT, TEST_TOKEN);
+        mapResponse.put(ApiConstants.TOKEN_TEXT, testToken);
         mapResponse.put("url_webpay", urlResponse);
 
         Gson gson = new GsonBuilder().create();
@@ -77,14 +81,14 @@ public class OneclickMallTest  extends TestBase {
 
         String returnUrl = "http://localhost:8081/oneclick-mall/finish";
 
-        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(OPTION)).start(USERNAME, EMAIL, returnUrl);
-        assertEquals(response.getToken(), TEST_TOKEN);
+        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(option)).start(username, email, returnUrl);
+        assertEquals(response.getToken(), testToken);
         assertEquals(response.getUrlWebpay(), urlResponse);
     }
 
     @Test
     public void finish() throws IOException, InscriptionFinishException {
-        String url = String.format("/%s/inscriptions/%s", API_URL, TEST_TOKEN);
+        String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
 
         byte responseCode = 0;
         String authorizationCode = "1213";
@@ -93,7 +97,7 @@ public class OneclickMallTest  extends TestBase {
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
         mapResponse.put("response_code", responseCode);
-        mapResponse.put("tbk_user", TBK_USER);
+        mapResponse.put("tbk_user", tbkUser);
         mapResponse.put("authorization_code", authorizationCode);
         mapResponse.put("card_type", cardType);
         mapResponse.put("card_number", cardNumber);
@@ -102,9 +106,9 @@ public class OneclickMallTest  extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(OPTION)).finish(TEST_TOKEN);
+        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
         assertEquals(response.getResponseCode(), responseCode);
-        assertEquals(response.getTbkUser(), TBK_USER);
+        assertEquals(response.getTbkUser(), tbkUser);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getCardType(), cardType);
         assertEquals(response.getCardNumber(), cardNumber);
@@ -114,34 +118,34 @@ public class OneclickMallTest  extends TestBase {
     private Map<String, Object> generateAutorizeJsonResponse(){
 
         Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
-        mapResponseCardDetail.put("card_number", CARD_NUMBER);
+        mapResponseCardDetail.put("card_number", cardNumber);
 
         Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
-        mapResponseDetail1.put("amount", AMOUNT_1);
-        mapResponseDetail1.put("status", STATUS_1);
-        mapResponseDetail1.put("authorization_code", AUTHORIZATION_CODE_1);
-        mapResponseDetail1.put("payment_type_code", PAYMENT_TYPE_CODE_1);
-        mapResponseDetail1.put("response_code", RESPONSE_CODE_1);
-        mapResponseDetail1.put("installments_number", INSTALLMENTS_NUMBER_1);
-        mapResponseDetail1.put("commerce_code", COMMERCE_CODE_1);
-        mapResponseDetail1.put("buy_order", BUY_ORDER_1);
+        mapResponseDetail1.put("amount", amount1);
+        mapResponseDetail1.put("status", status1);
+        mapResponseDetail1.put("authorization_code", authorizationCode1);
+        mapResponseDetail1.put("payment_type_code", paymentTypeCode1);
+        mapResponseDetail1.put("response_code", responseCode1);
+        mapResponseDetail1.put("installments_number", installmentsNumber1);
+        mapResponseDetail1.put("commerce_code", commerceCode1);
+        mapResponseDetail1.put("buy_order", buyOrder1);
 
         Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
-        mapResponseDetail2.put("amount", AMOUNT_2);
-        mapResponseDetail2.put("status", STATUS_2);
-        mapResponseDetail2.put("authorization_code", AUTHORIZATION_CODE_2);
-        mapResponseDetail2.put("payment_type_code", PAYMENT_TYPE_CODE_2);
-        mapResponseDetail2.put("response_code", RESPONSE_CODE_2);
-        mapResponseDetail2.put("installments_number", INSTALLMENTS_NUMBER_2);
-        mapResponseDetail2.put("commerce_code", COMMERCE_CODE_2);
-        mapResponseDetail2.put("buy_order", BUY_ORDER_2);
+        mapResponseDetail2.put("amount", amount2);
+        mapResponseDetail2.put("status", status2);
+        mapResponseDetail2.put("authorization_code", authorizationCode2);
+        mapResponseDetail2.put("payment_type_code", paymentTypeCode2);
+        mapResponseDetail2.put("response_code", responseCode2);
+        mapResponseDetail2.put("installments_number", installmentsNumber2);
+        mapResponseDetail2.put("commerce_code", commerceCode2);
+        mapResponseDetail2.put("buy_order", buyOrder2);
 
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("buy_order", BUY_ORDER);
+        mapResponse.put("buy_order", buyOrder);
         mapResponse.put("card_detail", mapResponseCardDetail);
-        mapResponse.put("accounting_date", ACCOUNTING_DATE);
-        mapResponse.put("transaction_date", TRANSACTION_DATE);
+        mapResponse.put("accounting_date", accountingDate);
+        mapResponse.put("transaction_date", transactionDate);
         //details
         List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
         lstDetail.add(mapResponseDetail1);
@@ -153,7 +157,7 @@ public class OneclickMallTest  extends TestBase {
 
     @Test
     public void authorize() throws IOException, TransactionAuthorizeException {
-        String url = String.format("/%s/transactions",API_URL);
+        String url = String.format("/%s/transactions",apiUrl);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
@@ -169,38 +173,38 @@ public class OneclickMallTest  extends TestBase {
         byte installmentsNumberMallTwo = 1;
 
         MallTransactionCreateDetails details = MallTransactionCreateDetails.build()
-                .add(amountMallOne, COMMERCE_CODE_1, buyOrderMallOne, installmentsNumberMallOne)
-                .add(amountMallTwo, COMMERCE_CODE_2, buyOrderMallTwo, installmentsNumberMallTwo);
+                .add(amountMallOne, commerceCode1, buyOrderMallOne, installmentsNumberMallOne)
+                .add(amountMallTwo, commerceCode2, buyOrderMallTwo, installmentsNumberMallTwo);
 
-        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(OPTION)).authorize(USERNAME, tbkUserReq, buyOrderReq, details);
+        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(option)).authorize(username, tbkUserReq, buyOrderReq, details);
 
-        assertEquals(response.getBuyOrder(), BUY_ORDER);
-        assertEquals(response.getCardDetail().getCardNumber(), CARD_NUMBER);
-        assertEquals(response.getAccountingDate(), ACCOUNTING_DATE);
-        assertEquals(response.getTransactionDate(), TRANSACTION_DATE);
+        assertEquals(response.getBuyOrder(), buyOrder);
+        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
+        assertEquals(response.getAccountingDate(), accountingDate);
+        assertEquals(response.getTransactionDate(), transactionDate);
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), AMOUNT_1);
-        assertEquals(response.getDetails().get(0).getStatus(), STATUS_1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), AUTHORIZATION_CODE_1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), PAYMENT_TYPE_CODE_1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), RESPONSE_CODE_1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), INSTALLMENTS_NUMBER_1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), COMMERCE_CODE_1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), BUY_ORDER_1);
+        assertEquals(response.getDetails().get(0).getAmount(), amount1);
+        assertEquals(response.getDetails().get(0).getStatus(), status1);
+        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
+        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
+        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
+        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
+        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
+        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), AMOUNT_2);
-        assertEquals(response.getDetails().get(1).getStatus(), STATUS_2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), AUTHORIZATION_CODE_2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), PAYMENT_TYPE_CODE_2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), RESPONSE_CODE_2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), INSTALLMENTS_NUMBER_2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), COMMERCE_CODE_2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), BUY_ORDER_2);
+        assertEquals(response.getDetails().get(1).getAmount(), amount2);
+        assertEquals(response.getDetails().get(1).getStatus(), status2);
+        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
+        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
+        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
+        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
+        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
+        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
     }
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        String url = String.format("/%s/transactions/%s/refunds", API_URL, BUY_ORDER);
+        String url = String.format("/%s/transactions/%s/refunds", apiUrl, buyOrder);
 
         String type = "REVERSED";
 
@@ -214,43 +218,43 @@ public class OneclickMallTest  extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(OPTION)).refund(BUY_ORDER, childCommerceCode, childBuyOrder, amount);
+        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(option)).refund(buyOrder, childCommerceCode, childBuyOrder, amount);
 
         assertEquals(response.getType(), type);
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        String url = String.format("/%s/transactions/%s", API_URL, BUY_ORDER);
+        String url = String.format("/%s/transactions/%s", apiUrl, buyOrder);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(OPTION)).status(BUY_ORDER);
+        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(buyOrder);
 
-        assertEquals(response.getBuyOrder(), BUY_ORDER);
-        assertEquals(response.getCardDetail().getCardNumber(), CARD_NUMBER);
-        assertEquals(response.getAccountingDate(), ACCOUNTING_DATE);
-        assertEquals(response.getTransactionDate(), TRANSACTION_DATE);
+        assertEquals(response.getBuyOrder(), buyOrder);
+        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
+        assertEquals(response.getAccountingDate(), accountingDate);
+        assertEquals(response.getTransactionDate(), transactionDate);
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), AMOUNT_1);
-        assertEquals(response.getDetails().get(0).getStatus(), STATUS_1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), AUTHORIZATION_CODE_1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), PAYMENT_TYPE_CODE_1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), RESPONSE_CODE_1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), INSTALLMENTS_NUMBER_1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), COMMERCE_CODE_1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), BUY_ORDER_1);
+        assertEquals(response.getDetails().get(0).getAmount(), amount1);
+        assertEquals(response.getDetails().get(0).getStatus(), status1);
+        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
+        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
+        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
+        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
+        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
+        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), AMOUNT_2);
-        assertEquals(response.getDetails().get(1).getStatus(), STATUS_2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), AUTHORIZATION_CODE_2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), PAYMENT_TYPE_CODE_2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), RESPONSE_CODE_2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), INSTALLMENTS_NUMBER_2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), COMMERCE_CODE_2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), BUY_ORDER_2);
+        assertEquals(response.getDetails().get(1).getAmount(), amount2);
+        assertEquals(response.getDetails().get(1).getStatus(), status2);
+        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
+        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
+        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
+        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
+        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
+        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
     }
 
 

--- a/src/test/java/webpayplus/OneclickMallTest.java
+++ b/src/test/java/webpayplus/OneclickMallTest.java
@@ -257,19 +257,4 @@ public class OneclickMallTest  extends TestBase {
         assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
     }
 
-
-    //{"username":"goncafa","tbk_user":"aaaaaaaaaaaaa-bbbbbbbb-cccccc"}
-    /*
-    @Test
-    public void delete() throws IOException, InscriptionDeleteException {
-        Oneclick.configureForMock();
-        String url = "/rswebpaytransaction/api/oneclick/v1.0/inscriptions";
-
-        //String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
-        Map<String, Object> mapResponse = new HashMap<>();
-        Gson gson = new GsonBuilder().create();
-        setResponse(url, gson.toJson(mapResponse));
-        Oneclick.MallInscription.delete(username, tbkUser);
-
-    }*/
 }

--- a/src/test/java/webpayplus/OneclickMallTest.java
+++ b/src/test/java/webpayplus/OneclickMallTest.java
@@ -90,28 +90,28 @@ public class OneclickMallTest  extends TestBase {
     public void finish() throws IOException, InscriptionFinishException {
         String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
 
-        byte responseCode = 0;
-        String authorizationCode = "1213";
+        byte responseCode3 = 0;
+        String authorizationCode3 = "1213";
         String cardType = "Visa";
-        String cardNumber = "XXXXXXXXXXXX6623";
+        String cardNumber3 = "XXXXXXXXXXXX6623";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("response_code", responseCode);
+        mapResponse.put("response_code", responseCode3);
         mapResponse.put("tbk_user", tbkUser);
-        mapResponse.put("authorization_code", authorizationCode);
+        mapResponse.put("authorization_code", authorizationCode3);
         mapResponse.put("card_type", cardType);
-        mapResponse.put("card_number", cardNumber);
+        mapResponse.put("card_number", cardNumber3);
 
         Gson gson = new GsonBuilder().create();
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
         final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
-        assertEquals(response.getResponseCode(), responseCode);
+        assertEquals(response.getResponseCode(), responseCode3);
         assertEquals(response.getTbkUser(), tbkUser);
-        assertEquals(response.getAuthorizationCode(), authorizationCode);
+        assertEquals(response.getAuthorizationCode(), authorizationCode3);
         assertEquals(response.getCardType(), cardType);
-        assertEquals(response.getCardNumber(), cardNumber);
+        assertEquals(response.getCardNumber(), cardNumber3);
 
     }
 

--- a/src/test/java/webpayplus/OneclickMallTest.java
+++ b/src/test/java/webpayplus/OneclickMallTest.java
@@ -24,37 +24,33 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 public class OneclickMallTest  extends TestBase {
 
-    private static String apiUrl = ApiConstants.ONECLICK_ENDPOINT;
-    private static Options option = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL,
+    private static String API_URL = ApiConstants.ONECLICK_ENDPOINT;
+    private static Options OPTION = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
-    private static String username = "goncafa";
-    private static String email = "gonzalo.castillo@continuum.cl";
-    private static String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
-
-    private static String cardNumber = "6623";
-    private static String transactionDate = "2021-08-01T05:30:06.557Z";
-    private static String accountingDate = "0801";
-    private static String buyOrder = "724900565";
-
-    private static double amount1 = 1000d;
-    private static String status1 = "AUTHORIZED";
-    private static String authorizationCode1 = "1213";
-    private static String paymentTypeCode1 = "VN";
-    private static byte installmentsNumber1 = 0;
-    private static String commerceCode1 = "597055555542";
-    private static String buyOrder1 = "2019439134";
-    private static byte responseCode1 = 0;
-
-    private static double amount2 = 1000d;
-    private static String status2 = "AUTHORIZED";
-    private static String authorizationCode2 = "1213";
-    private static String paymentTypeCode2 = "VN";
-    private static byte installmentsNumber2 = 0;
-    private static String commerceCode2 = "597055555543";
-    private static String buyOrder2 = "353345213";
-    private static byte responseCode2 = 0;
-
-    private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    private static String USERNAME = "goncafa";
+    private static String EMAIL = "gonzalo.castillo@continuum.cl";
+    private static String TBK_USER = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
+    private static String CARD_NUMBER = "6623";
+    private static String TRANSACTION_DATE = "2021-08-01T05:30:06.557Z";
+    private static String ACCOUNTING_DATE = "0801";
+    private static String BUY_ORDER = "724900565";
+    private static double AMOUNT_1 = 1000d;
+    private static String STATUS_1 = "AUTHORIZED";
+    private static String AUTHORIZATION_CODE_1 = "1213";
+    private static String PAYMENT_TYPE_CODE_1 = "VN";
+    private static byte INSTALLMENTS_NUMBER_1 = 0;
+    private static String COMMERCE_CODE_1 = "597055555542";
+    private static String BUY_ORDER_1 = "2019439134";
+    private static byte RESPONSE_CODE_1 = 0;
+    private static double AMOUNT_2 = 1000d;
+    private static String STATUS_2 = "AUTHORIZED";
+    private static String AUTHORIZATION_CODE_2 = "1213";
+    private static String PAYMENT_TYPE_CODE_2 = "VN";
+    private static byte INSTALLMENTS_NUMBER_2 = 0;
+    private static String COMMERCE_CODE_2 = "597055555543";
+    private static String BUY_ORDER_2 = "353345213";
+    private static byte RESPONSE_CODE_2 = 0;
+    private static String TEST_TOKEN = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
     public static void startProxy() {
@@ -68,11 +64,11 @@ public class OneclickMallTest  extends TestBase {
 
     @Test
     public void start() throws IOException, InscriptionStartException {
-        String url = String.format("/%s/inscriptions",apiUrl);
+        String url = String.format("/%s/inscriptions",API_URL);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/bp_multicode_inscription.cgi";
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put(ApiConstants.TOKEN_TEXT, testToken);
+        mapResponse.put(ApiConstants.TOKEN_TEXT, TEST_TOKEN);
         mapResponse.put("url_webpay", urlResponse);
 
         Gson gson = new GsonBuilder().create();
@@ -81,14 +77,14 @@ public class OneclickMallTest  extends TestBase {
 
         String returnUrl = "http://localhost:8081/oneclick-mall/finish";
 
-        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(option)).start(username, email, returnUrl);
-        assertEquals(response.getToken(), testToken);
+        final OneclickMallInscriptionStartResponse response = (new Oneclick.MallInscription(OPTION)).start(USERNAME, EMAIL, returnUrl);
+        assertEquals(response.getToken(), TEST_TOKEN);
         assertEquals(response.getUrlWebpay(), urlResponse);
     }
 
     @Test
     public void finish() throws IOException, InscriptionFinishException {
-        String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
+        String url = String.format("/%s/inscriptions/%s", API_URL, TEST_TOKEN);
 
         byte responseCode = 0;
         String authorizationCode = "1213";
@@ -97,7 +93,7 @@ public class OneclickMallTest  extends TestBase {
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
         mapResponse.put("response_code", responseCode);
-        mapResponse.put("tbk_user", tbkUser);
+        mapResponse.put("tbk_user", TBK_USER);
         mapResponse.put("authorization_code", authorizationCode);
         mapResponse.put("card_type", cardType);
         mapResponse.put("card_number", cardNumber);
@@ -106,9 +102,9 @@ public class OneclickMallTest  extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
+        final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(OPTION)).finish(TEST_TOKEN);
         assertEquals(response.getResponseCode(), responseCode);
-        assertEquals(response.getTbkUser(), tbkUser);
+        assertEquals(response.getTbkUser(), TBK_USER);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getCardType(), cardType);
         assertEquals(response.getCardNumber(), cardNumber);
@@ -118,34 +114,34 @@ public class OneclickMallTest  extends TestBase {
     private Map<String, Object> generateAutorizeJsonResponse(){
 
         Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
-        mapResponseCardDetail.put("card_number", cardNumber);
+        mapResponseCardDetail.put("card_number", CARD_NUMBER);
 
         Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
-        mapResponseDetail1.put("amount", amount1);
-        mapResponseDetail1.put("status", status1);
-        mapResponseDetail1.put("authorization_code", authorizationCode1);
-        mapResponseDetail1.put("payment_type_code", paymentTypeCode1);
-        mapResponseDetail1.put("response_code", responseCode1);
-        mapResponseDetail1.put("installments_number", installmentsNumber1);
-        mapResponseDetail1.put("commerce_code", commerceCode1);
-        mapResponseDetail1.put("buy_order", buyOrder1);
+        mapResponseDetail1.put("amount", AMOUNT_1);
+        mapResponseDetail1.put("status", STATUS_1);
+        mapResponseDetail1.put("authorization_code", AUTHORIZATION_CODE_1);
+        mapResponseDetail1.put("payment_type_code", PAYMENT_TYPE_CODE_1);
+        mapResponseDetail1.put("response_code", RESPONSE_CODE_1);
+        mapResponseDetail1.put("installments_number", INSTALLMENTS_NUMBER_1);
+        mapResponseDetail1.put("commerce_code", COMMERCE_CODE_1);
+        mapResponseDetail1.put("buy_order", BUY_ORDER_1);
 
         Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
-        mapResponseDetail2.put("amount", amount2);
-        mapResponseDetail2.put("status", status2);
-        mapResponseDetail2.put("authorization_code", authorizationCode2);
-        mapResponseDetail2.put("payment_type_code", paymentTypeCode2);
-        mapResponseDetail2.put("response_code", responseCode2);
-        mapResponseDetail2.put("installments_number", installmentsNumber2);
-        mapResponseDetail2.put("commerce_code", commerceCode2);
-        mapResponseDetail2.put("buy_order", buyOrder2);
+        mapResponseDetail2.put("amount", AMOUNT_2);
+        mapResponseDetail2.put("status", STATUS_2);
+        mapResponseDetail2.put("authorization_code", AUTHORIZATION_CODE_2);
+        mapResponseDetail2.put("payment_type_code", PAYMENT_TYPE_CODE_2);
+        mapResponseDetail2.put("response_code", RESPONSE_CODE_2);
+        mapResponseDetail2.put("installments_number", INSTALLMENTS_NUMBER_2);
+        mapResponseDetail2.put("commerce_code", COMMERCE_CODE_2);
+        mapResponseDetail2.put("buy_order", BUY_ORDER_2);
 
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("buy_order", buyOrder);
+        mapResponse.put("buy_order", BUY_ORDER);
         mapResponse.put("card_detail", mapResponseCardDetail);
-        mapResponse.put("accounting_date", accountingDate);
-        mapResponse.put("transaction_date", transactionDate);
+        mapResponse.put("accounting_date", ACCOUNTING_DATE);
+        mapResponse.put("transaction_date", TRANSACTION_DATE);
         //details
         List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
         lstDetail.add(mapResponseDetail1);
@@ -157,7 +153,7 @@ public class OneclickMallTest  extends TestBase {
 
     @Test
     public void authorize() throws IOException, TransactionAuthorizeException {
-        String url = String.format("/%s/transactions",apiUrl);
+        String url = String.format("/%s/transactions",API_URL);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
@@ -173,38 +169,38 @@ public class OneclickMallTest  extends TestBase {
         byte installmentsNumberMallTwo = 1;
 
         MallTransactionCreateDetails details = MallTransactionCreateDetails.build()
-                .add(amountMallOne, commerceCode1, buyOrderMallOne, installmentsNumberMallOne)
-                .add(amountMallTwo, commerceCode2, buyOrderMallTwo, installmentsNumberMallTwo);
+                .add(amountMallOne, COMMERCE_CODE_1, buyOrderMallOne, installmentsNumberMallOne)
+                .add(amountMallTwo, COMMERCE_CODE_2, buyOrderMallTwo, installmentsNumberMallTwo);
 
-        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(option)).authorize(username, tbkUserReq, buyOrderReq, details);
+        final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(OPTION)).authorize(USERNAME, tbkUserReq, buyOrderReq, details);
 
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getBuyOrder(), BUY_ORDER);
+        assertEquals(response.getCardDetail().getCardNumber(), CARD_NUMBER);
+        assertEquals(response.getAccountingDate(), ACCOUNTING_DATE);
+        assertEquals(response.getTransactionDate(), TRANSACTION_DATE);
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        assertEquals(response.getDetails().get(0).getAmount(), AMOUNT_1);
+        assertEquals(response.getDetails().get(0).getStatus(), STATUS_1);
+        assertEquals(response.getDetails().get(0).getAuthorizationCode(), AUTHORIZATION_CODE_1);
+        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), PAYMENT_TYPE_CODE_1);
+        assertEquals(response.getDetails().get(0).getResponseCode(), RESPONSE_CODE_1);
+        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), INSTALLMENTS_NUMBER_1);
+        assertEquals(response.getDetails().get(0).getCommerceCode(), COMMERCE_CODE_1);
+        assertEquals(response.getDetails().get(0).getBuyOrder(), BUY_ORDER_1);
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        assertEquals(response.getDetails().get(1).getAmount(), AMOUNT_2);
+        assertEquals(response.getDetails().get(1).getStatus(), STATUS_2);
+        assertEquals(response.getDetails().get(1).getAuthorizationCode(), AUTHORIZATION_CODE_2);
+        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), PAYMENT_TYPE_CODE_2);
+        assertEquals(response.getDetails().get(1).getResponseCode(), RESPONSE_CODE_2);
+        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), INSTALLMENTS_NUMBER_2);
+        assertEquals(response.getDetails().get(1).getCommerceCode(), COMMERCE_CODE_2);
+        assertEquals(response.getDetails().get(1).getBuyOrder(), BUY_ORDER_2);
     }
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        String url = String.format("/%s/transactions/%s/refunds", apiUrl, buyOrder);
+        String url = String.format("/%s/transactions/%s/refunds", API_URL, BUY_ORDER);
 
         String type = "REVERSED";
 
@@ -218,43 +214,43 @@ public class OneclickMallTest  extends TestBase {
         String childCommerceCode = "597055555542";
         String childBuyOrder = "2019439134";
         double amount = 1000d;
-        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(option)).refund(buyOrder, childCommerceCode, childBuyOrder, amount);
+        final OneclickMallTransactionRefundResponse response = (new Oneclick.MallTransaction(OPTION)).refund(BUY_ORDER, childCommerceCode, childBuyOrder, amount);
 
         assertEquals(response.getType(), type);
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        String url = String.format("/%s/transactions/%s", apiUrl, buyOrder);
+        String url = String.format("/%s/transactions/%s", API_URL, BUY_ORDER);
 
         Map<String, Object> mapResponse = generateAutorizeJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(buyOrder);
+        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(OPTION)).status(BUY_ORDER);
 
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getBuyOrder(), BUY_ORDER);
+        assertEquals(response.getCardDetail().getCardNumber(), CARD_NUMBER);
+        assertEquals(response.getAccountingDate(), ACCOUNTING_DATE);
+        assertEquals(response.getTransactionDate(), TRANSACTION_DATE);
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        assertEquals(response.getDetails().get(0).getAmount(), AMOUNT_1);
+        assertEquals(response.getDetails().get(0).getStatus(), STATUS_1);
+        assertEquals(response.getDetails().get(0).getAuthorizationCode(), AUTHORIZATION_CODE_1);
+        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), PAYMENT_TYPE_CODE_1);
+        assertEquals(response.getDetails().get(0).getResponseCode(), RESPONSE_CODE_1);
+        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), INSTALLMENTS_NUMBER_1);
+        assertEquals(response.getDetails().get(0).getCommerceCode(), COMMERCE_CODE_1);
+        assertEquals(response.getDetails().get(0).getBuyOrder(), BUY_ORDER_1);
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        assertEquals(response.getDetails().get(1).getAmount(), AMOUNT_2);
+        assertEquals(response.getDetails().get(1).getStatus(), STATUS_2);
+        assertEquals(response.getDetails().get(1).getAuthorizationCode(), AUTHORIZATION_CODE_2);
+        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), PAYMENT_TYPE_CODE_2);
+        assertEquals(response.getDetails().get(1).getResponseCode(), RESPONSE_CODE_2);
+        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), INSTALLMENTS_NUMBER_2);
+        assertEquals(response.getDetails().get(1).getCommerceCode(), COMMERCE_CODE_2);
+        assertEquals(response.getDetails().get(1).getBuyOrder(), BUY_ORDER_2);
     }
 
 

--- a/src/test/java/webpayplus/OneclickMallTest.java
+++ b/src/test/java/webpayplus/OneclickMallTest.java
@@ -17,12 +17,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.*;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
-
-public class OneclickMallTest  extends TestBase {
+public class OneclickMallTest  extends OneclickMallTestBase {
 
     private static String apiUrl = ApiConstants.ONECLICK_ENDPOINT;
     private static Options option = new WebpayOptions(IntegrationCommerceCodes.ONECLICK_MALL,
@@ -30,30 +28,8 @@ public class OneclickMallTest  extends TestBase {
     private static String username = "goncafa";
     private static String email = "gonzalo.castillo@continuum.cl";
     private static String tbkUser = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
-
-    private static String cardNumber = "6623";
-    private static String transactionDate = "2021-08-01T05:30:06.557Z";
-    private static String accountingDate = "0801";
-    private static String buyOrder = "724900565";
-
-    private static double amount1 = 1000d;
-    private static String status1 = "AUTHORIZED";
-    private static String authorizationCode1 = "1213";
-    private static String paymentTypeCode1 = "VN";
-    private static byte installmentsNumber1 = 0;
     private static String commerceCode1 = "597055555542";
-    private static String buyOrder1 = "2019439134";
-    private static byte responseCode1 = 0;
-
-    private static double amount2 = 1000d;
-    private static String status2 = "AUTHORIZED";
-    private static String authorizationCode2 = "1213";
-    private static String paymentTypeCode2 = "VN";
-    private static byte installmentsNumber2 = 0;
     private static String commerceCode2 = "597055555543";
-    private static String buyOrder2 = "353345213";
-    private static byte responseCode2 = 0;
-
     private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
@@ -90,78 +66,35 @@ public class OneclickMallTest  extends TestBase {
     public void finish() throws IOException, InscriptionFinishException {
         String url = String.format("/%s/inscriptions/%s", apiUrl, testToken);
 
-        byte responseCode3 = 0;
-        String authorizationCode3 = "1213";
+        byte responseCode = 0;
+        String authorizationCode = "1213";
         String cardType = "Visa";
-        String cardNumber3 = "XXXXXXXXXXXX6623";
+        String cardNumber = "XXXXXXXXXXXX6623";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("response_code", responseCode3);
+        mapResponse.put("response_code", responseCode);
         mapResponse.put("tbk_user", tbkUser);
-        mapResponse.put("authorization_code", authorizationCode3);
+        mapResponse.put("authorization_code", authorizationCode);
         mapResponse.put("card_type", cardType);
-        mapResponse.put("card_number", cardNumber3);
+        mapResponse.put("card_number", cardNumber);
 
         Gson gson = new GsonBuilder().create();
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
         final OneclickMallInscriptionFinishResponse response = (new Oneclick.MallInscription(option)).finish(testToken);
-        assertEquals(response.getResponseCode(), responseCode3);
+        assertEquals(response.getResponseCode(), responseCode);
         assertEquals(response.getTbkUser(), tbkUser);
-        assertEquals(response.getAuthorizationCode(), authorizationCode3);
+        assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getCardType(), cardType);
-        assertEquals(response.getCardNumber(), cardNumber3);
+        assertEquals(response.getCardNumber(), cardNumber);
 
     }
-
-    private Map<String, Object> generateAutorizeJsonResponse(){
-
-        Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
-        mapResponseCardDetail.put("card_number", cardNumber);
-
-        Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
-        mapResponseDetail1.put("amount", amount1);
-        mapResponseDetail1.put("status", status1);
-        mapResponseDetail1.put("authorization_code", authorizationCode1);
-        mapResponseDetail1.put("payment_type_code", paymentTypeCode1);
-        mapResponseDetail1.put("response_code", responseCode1);
-        mapResponseDetail1.put("installments_number", installmentsNumber1);
-        mapResponseDetail1.put("commerce_code", commerceCode1);
-        mapResponseDetail1.put("buy_order", buyOrder1);
-
-        Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
-        mapResponseDetail2.put("amount", amount2);
-        mapResponseDetail2.put("status", status2);
-        mapResponseDetail2.put("authorization_code", authorizationCode2);
-        mapResponseDetail2.put("payment_type_code", paymentTypeCode2);
-        mapResponseDetail2.put("response_code", responseCode2);
-        mapResponseDetail2.put("installments_number", installmentsNumber2);
-        mapResponseDetail2.put("commerce_code", commerceCode2);
-        mapResponseDetail2.put("buy_order", buyOrder2);
-
-
-        Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("buy_order", buyOrder);
-        mapResponse.put("card_detail", mapResponseCardDetail);
-        mapResponse.put("accounting_date", accountingDate);
-        mapResponse.put("transaction_date", transactionDate);
-        //details
-        List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
-        lstDetail.add(mapResponseDetail1);
-        lstDetail.add(mapResponseDetail2);
-        mapResponse.put("details", lstDetail);
-
-        return mapResponse;
-    }
-
     @Test
     public void authorize() throws IOException, TransactionAuthorizeException {
+        OneclickMallTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions",apiUrl);
-
-        Map<String, Object> mapResponse = generateAutorizeJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponsePost(url, gson.toJson(mapResponse));
+        setResponsePost(url, generateJsonResponse());
 
         String tbkUserReq = "aaaaaaaaaaaaa-bbbbbbbb-cccccc";
         String buyOrderReq = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
@@ -178,32 +111,37 @@ public class OneclickMallTest  extends TestBase {
 
         final OneclickMallTransactionAuthorizeResponse response = (new Oneclick.MallTransaction(option)).authorize(username, tbkUserReq, buyOrderReq, details);
 
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getBuyOrder(), expectedResponse.getBuyOrder());
+        assertEquals(response.getCardDetail().getCardNumber(), expectedResponse.getCardDetail().getCardNumber());
+        assertEquals(response.getAccountingDate(), expectedResponse.getAccountingDate());
+        assertEquals(response.getTransactionDate(), expectedResponse.getTransactionDate());
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        OneclickMallTransactionStatusResponse.Detail expectedDetail1 = expectedResponse.getDetails().get(0);
+        OneclickMallTransactionAuthorizeResponse.Detail detail1 = response.getDetails().get(0);
+        assertEquals(detail1.getAmount(), expectedDetail1.getAmount());
+        assertEquals(detail1.getStatus(), expectedDetail1.getStatus());
+        assertEquals(detail1.getAuthorizationCode(), expectedDetail1.getAuthorizationCode());
+        assertEquals(detail1.getPaymentTypeCode(), expectedDetail1.getPaymentTypeCode());
+        assertEquals(detail1.getResponseCode(), expectedDetail1.getResponseCode());
+        assertEquals(detail1.getInstallmentsNumber(), expectedDetail1.getInstallmentsNumber());
+        assertEquals(detail1.getCommerceCode(), expectedDetail1.getCommerceCode());
+        assertEquals(detail1.getBuyOrder(), expectedDetail1.getBuyOrder());
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        OneclickMallTransactionStatusResponse.Detail expectedDetail2 = expectedResponse.getDetails().get(1);
+        OneclickMallTransactionAuthorizeResponse.Detail detail2 = response.getDetails().get(1);
+        assertEquals(detail2.getAmount(), expectedDetail2.getAmount());
+        assertEquals(detail2.getStatus(), expectedDetail2.getStatus());
+        assertEquals(detail2.getAuthorizationCode(), expectedDetail2.getAuthorizationCode());
+        assertEquals(detail2.getPaymentTypeCode(), expectedDetail2.getPaymentTypeCode());
+        assertEquals(detail2.getResponseCode(), expectedDetail2.getResponseCode());
+        assertEquals(detail2.getInstallmentsNumber(), expectedDetail2.getInstallmentsNumber());
+        assertEquals(detail2.getCommerceCode(), expectedDetail2.getCommerceCode());
+        assertEquals(detail2.getBuyOrder(), expectedDetail2.getBuyOrder());
     }
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
+        String buyOrder = "1643997337";
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, buyOrder);
 
         String type = "REVERSED";
@@ -225,36 +163,38 @@ public class OneclickMallTest  extends TestBase {
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        String url = String.format("/%s/transactions/%s", apiUrl, buyOrder);
+        OneclickMallTransactionStatusResponse expectedResponse = generateStatusResponse();
+        String url = String.format("/%s/transactions/%s", apiUrl, expectedResponse.getBuyOrder());
+        setResponseGet(url, generateJsonResponse());
 
-        Map<String, Object> mapResponse = generateAutorizeJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponseGet(url, gson.toJson(mapResponse));
+        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(expectedResponse.getBuyOrder());
 
-        final OneclickMallTransactionStatusResponse response = (new Oneclick.MallTransaction(option)).status(buyOrder);
-
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getBuyOrder(), expectedResponse.getBuyOrder());
+        assertEquals(response.getCardDetail().getCardNumber(), expectedResponse.getCardDetail().getCardNumber());
+        assertEquals(response.getAccountingDate(), expectedResponse.getAccountingDate());
+        assertEquals(response.getTransactionDate(), expectedResponse.getTransactionDate());
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        OneclickMallTransactionStatusResponse.Detail expectedDetail1 = expectedResponse.getDetails().get(0);
+        OneclickMallTransactionStatusResponse.Detail detail1 = response.getDetails().get(0);
+        assertEquals(detail1.getAmount(), expectedDetail1.getAmount());
+        assertEquals(detail1.getStatus(), expectedDetail1.getStatus());
+        assertEquals(detail1.getAuthorizationCode(), expectedDetail1.getAuthorizationCode());
+        assertEquals(detail1.getPaymentTypeCode(), expectedDetail1.getPaymentTypeCode());
+        assertEquals(detail1.getResponseCode(), expectedDetail1.getResponseCode());
+        assertEquals(detail1.getInstallmentsNumber(), expectedDetail1.getInstallmentsNumber());
+        assertEquals(detail1.getCommerceCode(), expectedDetail1.getCommerceCode());
+        assertEquals(detail1.getBuyOrder(), expectedDetail1.getBuyOrder());
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        OneclickMallTransactionStatusResponse.Detail expectedDetail2 = expectedResponse.getDetails().get(1);
+        OneclickMallTransactionStatusResponse.Detail detail2 = response.getDetails().get(1);
+        assertEquals(detail2.getAmount(), expectedDetail2.getAmount());
+        assertEquals(detail2.getStatus(), expectedDetail2.getStatus());
+        assertEquals(detail2.getAuthorizationCode(), expectedDetail2.getAuthorizationCode());
+        assertEquals(detail2.getPaymentTypeCode(), expectedDetail2.getPaymentTypeCode());
+        assertEquals(detail2.getResponseCode(), expectedDetail2.getResponseCode());
+        assertEquals(detail2.getInstallmentsNumber(), expectedDetail2.getInstallmentsNumber());
+        assertEquals(detail2.getCommerceCode(), expectedDetail2.getCommerceCode());
+        assertEquals(detail2.getBuyOrder(), expectedDetail2.getBuyOrder());
     }
 
 }

--- a/src/test/java/webpayplus/OneclickMallTestBase.java
+++ b/src/test/java/webpayplus/OneclickMallTestBase.java
@@ -1,0 +1,59 @@
+package webpayplus;
+
+import cl.transbank.webpay.oneclick.responses.OneclickMallTransactionStatusResponse;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class OneclickMallTestBase extends TestBase {
+    protected String generateJsonResponse(){
+        Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
+        mapResponseCardDetail.put("card_number", "6623");
+
+        Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
+        mapResponseDetail1.put("amount", 1000d);
+        mapResponseDetail1.put("status", "AUTHORIZED");
+        mapResponseDetail1.put("authorization_code", "1213");
+        mapResponseDetail1.put("payment_type_code", "VN");
+        mapResponseDetail1.put("response_code", (byte)0);
+        mapResponseDetail1.put("installments_number", (byte)0);
+        mapResponseDetail1.put("commerce_code", "597055555536");
+        mapResponseDetail1.put("buy_order", "500894028");
+
+        Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
+        mapResponseDetail2.put("amount", 2000d);
+        mapResponseDetail2.put("status", "AUTHORIZED");
+        mapResponseDetail2.put("authorization_code", "1213");
+        mapResponseDetail2.put("payment_type_code", "VN");
+        mapResponseDetail2.put("response_code", (byte)0);
+        mapResponseDetail2.put("installments_number", (byte)0);
+        mapResponseDetail2.put("commerce_code", "597055555537");
+        mapResponseDetail2.put("buy_order", "1936357040");
+
+        Map<String, Object> mapResponse = new HashMap<String, Object>();
+        mapResponse.put("vci", "TSY");
+        mapResponse.put("buy_order", "1643997337");
+        mapResponse.put("session_id", "1134425622");
+        mapResponse.put("card_detail", mapResponseCardDetail);
+        mapResponse.put("accounting_date", "0731");
+        mapResponse.put("transaction_date", "2021-07-31T23:31:14.249Z");
+        //details
+        List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
+        lstDetail.add(mapResponseDetail1);
+        lstDetail.add(mapResponseDetail2);
+        mapResponse.put("details", lstDetail);
+
+        Gson gson = new GsonBuilder().create();
+        return gson.toJson(mapResponse);
+    }
+    protected OneclickMallTransactionStatusResponse generateStatusResponse() {
+        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+        return gson.fromJson(generateJsonResponse(), OneclickMallTransactionStatusResponse.class);
+    }
+
+}

--- a/src/test/java/webpayplus/PatpassByWebpayTest.java
+++ b/src/test/java/webpayplus/PatpassByWebpayTest.java
@@ -1,7 +1,12 @@
 package webpayplus;
 
 import cl.transbank.common.ApiConstants;
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.common.IntegrationType;
+import cl.transbank.model.Options;
 import cl.transbank.patpass.PatpassByWebpay;
+import cl.transbank.patpass.model.PatpassOptions;
 import cl.transbank.patpass.responses.PatpassByWebpayTransactionCommitResponse;
 import cl.transbank.patpass.responses.PatpassByWebpayTransactionCreateResponse;
 import cl.transbank.patpass.responses.PatpassByWebpayTransactionRefundResponse;
@@ -27,7 +32,8 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 public class PatpassByWebpayTest  extends TestBase {
 
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
-
+    private static Options option = new PatpassOptions(IntegrationCommerceCodes.PATPASS_BY_WEBPAY,
+            IntegrationApiKeys.PATPASS_COMERCIO, IntegrationType.SERVER_MOCK);
     private static String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
     private static String sessionId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
     private static String serviceId = nextString(20);
@@ -67,7 +73,7 @@ public class PatpassByWebpayTest  extends TestBase {
 
     @Test
     public void start() throws IOException, TransactionCreateException {
-        PatpassByWebpay.configureForMock();
+        
         String url = String.format("/%s/transactions",apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -81,7 +87,7 @@ public class PatpassByWebpayTest  extends TestBase {
 
         String returnUrl = "http://localhost:8081/patpass-webpay/commit";
 
-        PatpassByWebpayTransactionCreateResponse response = (new PatpassByWebpay.Transaction()).create(buyOrder, sessionId, 1000, returnUrl, serviceId, cardHolderId, cardHolderName,
+        PatpassByWebpayTransactionCreateResponse response = (new PatpassByWebpay.Transaction(option)).create(buyOrder, sessionId, 1000, returnUrl, serviceId, cardHolderId, cardHolderName,
                 cardHolderLastName1, cardHolderLastName2, cardHolderMail, cellphoneNumber, expirationDate, commerceMail, false);
 
         assertEquals(response.getToken(), testToken);
@@ -113,14 +119,14 @@ public class PatpassByWebpayTest  extends TestBase {
 
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        PatpassByWebpay.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponsePut(url, gson.toJson(mapResponse));
 
-        final PatpassByWebpayTransactionCommitResponse response = (new PatpassByWebpay.Transaction()).commit(testToken);
+        final PatpassByWebpayTransactionCommitResponse response = (new PatpassByWebpay.Transaction(option)).commit(testToken);
 
         assertEquals(response.getVci(), vci);
         assertEquals(response.getAmount(), amount);
@@ -140,14 +146,14 @@ public class PatpassByWebpayTest  extends TestBase {
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        PatpassByWebpay.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final PatpassByWebpayTransactionStatusResponse response = (new PatpassByWebpay.Transaction()).status(testToken);
+        final PatpassByWebpayTransactionStatusResponse response = (new PatpassByWebpay.Transaction(option)).status(testToken);
 
         assertEquals(response.getVci(), vci);
         assertEquals(response.getAmount(), amount);
@@ -165,7 +171,7 @@ public class PatpassByWebpayTest  extends TestBase {
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        PatpassByWebpay.configureForMock();
+        
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
 
         double amount = 1000d;
@@ -178,7 +184,7 @@ public class PatpassByWebpayTest  extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final PatpassByWebpayTransactionRefundResponse response = (new PatpassByWebpay.Transaction()).refund(testToken, amount);
+        final PatpassByWebpayTransactionRefundResponse response = (new PatpassByWebpay.Transaction(option)).refund(testToken, amount);
         assertEquals(response.getType(), type);
 
     }

--- a/src/test/java/webpayplus/PatpassByWebpayTest.java
+++ b/src/test/java/webpayplus/PatpassByWebpayTest.java
@@ -139,7 +139,7 @@ public class PatpassByWebpayTest  extends TestBase {
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getPaymentTypeCode(), paymentTypeCode);
         assertEquals(response.getResponseCode(), responseCode);
-        //assertEquals(response.getInstallmentsAmount(), mapResponse.get("amount"));
+        
         assertEquals(response.getInstallmentsNumber(), installmentsNumber);
     }
 
@@ -165,7 +165,7 @@ public class PatpassByWebpayTest  extends TestBase {
         assertEquals(response.getTransactionDate(), transactionDate);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getPaymentTypeCode(), paymentTypeCode);
-        //assertEquals(response.getInstallmentsAmount(), mapResponse.get("amount"));
+        
         assertEquals(response.getInstallmentsNumber(), installmentsNumber);
     }
 

--- a/src/test/java/webpayplus/PatpassByWebpayTest.java
+++ b/src/test/java/webpayplus/PatpassByWebpayTest.java
@@ -174,7 +174,7 @@ public class PatpassByWebpayTest  extends TestBase {
         
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
 
-        double amount = 1000d;
+        double amount3 = 1000d;
         String type = "REVERSED";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
@@ -184,7 +184,7 @@ public class PatpassByWebpayTest  extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final PatpassByWebpayTransactionRefundResponse response = (new PatpassByWebpay.Transaction(option)).refund(testToken, amount);
+        final PatpassByWebpayTransactionRefundResponse response = (new PatpassByWebpay.Transaction(option)).refund(testToken, amount3);
         assertEquals(response.getType(), type);
 
     }

--- a/src/test/java/webpayplus/PatpassComercioTest.java
+++ b/src/test/java/webpayplus/PatpassComercioTest.java
@@ -62,7 +62,6 @@ public class PatpassComercioTest extends TestBase {
         String rut = "14140066-5";
         String serviceId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
         String finalUrl = "http://localhost:8081/patpass-comercio/final";
-        String commerceCode = "28299257";
         double maxAmount = 0;
         String phoneNumber = "123456734";
         String mobileNumber = "123456723";
@@ -72,7 +71,6 @@ public class PatpassComercioTest extends TestBase {
         String address = "huerfanos 101";
         String city = "Santiago";
 
-        //PatpassComercio.setCommerceCode(commerceCode);
         final PatpassComercioInscriptionStartResponse response = (new PatpassComercio.Inscription(option)).start(urlRequest,
                 name,
                 firstLastName,
@@ -107,8 +105,6 @@ public class PatpassComercioTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        String commerceCode = "28299257";
-        //PatpassComercio.setCommerceCode(commerceCode);
         final PatpassComercioTransactionStatusResponse response = (new PatpassComercio.Inscription(option)).status(testToken);
 
         assertEquals(response.isAuthorized(), true);

--- a/src/test/java/webpayplus/PatpassComercioTest.java
+++ b/src/test/java/webpayplus/PatpassComercioTest.java
@@ -1,7 +1,12 @@
 package webpayplus;
 
 import cl.transbank.common.ApiConstants;
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.common.IntegrationType;
+import cl.transbank.model.Options;
 import cl.transbank.patpass.PatpassComercio;
+import cl.transbank.patpass.model.PatpassOptions;
 import cl.transbank.patpass.responses.PatpassComercioInscriptionStartResponse;
 import cl.transbank.patpass.responses.PatpassComercioTransactionStatusResponse;
 import cl.transbank.webpay.exception.InscriptionStartException;
@@ -22,6 +27,8 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 public class PatpassComercioTest extends TestBase {
 
     private static String apiUrl = ApiConstants.PATPASS_COMERCIO_ENDPOINT;
+    private static Options option = new PatpassOptions(IntegrationCommerceCodes.PATPASS_COMERCIO,
+            IntegrationApiKeys.PATPASS_COMERCIO, IntegrationType.SERVER_MOCK);
     private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
@@ -36,7 +43,7 @@ public class PatpassComercioTest extends TestBase {
 
     @Test
     public void start() throws IOException, InscriptionStartException {
-        PatpassComercio.configureForMock();
+        
         String url = String.format("/%s/patInscription", apiUrl);
 
         String urlResponse = "https://pagoautomaticocontarjetasint.transbank.cl/nuevo-ic-rest/tokenComercioLogin";
@@ -66,7 +73,7 @@ public class PatpassComercioTest extends TestBase {
         String city = "Santiago";
 
         //PatpassComercio.setCommerceCode(commerceCode);
-        final PatpassComercioInscriptionStartResponse response = (new PatpassComercio.Inscription()).start(urlRequest,
+        final PatpassComercioInscriptionStartResponse response = (new PatpassComercio.Inscription(option)).start(urlRequest,
                 name,
                 firstLastName,
                 secondLastName,
@@ -88,7 +95,7 @@ public class PatpassComercioTest extends TestBase {
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        PatpassComercio.configureForMock();
+        
         String url = String.format("/%s/status", apiUrl);
 
         String urlResponse = "https://pagoautomaticocontarjetasint.transbank.cl/nuevo-ic-rest/tokenVoucherLogin";
@@ -102,7 +109,7 @@ public class PatpassComercioTest extends TestBase {
 
         String commerceCode = "28299257";
         //PatpassComercio.setCommerceCode(commerceCode);
-        final PatpassComercioTransactionStatusResponse response = (new PatpassComercio.Inscription()).status(testToken);
+        final PatpassComercioTransactionStatusResponse response = (new PatpassComercio.Inscription(option)).status(testToken);
 
         assertEquals(response.isAuthorized(), true);
         assertEquals(response.getVoucherUrl(), urlResponse);

--- a/src/test/java/webpayplus/WebpayModalTest.java
+++ b/src/test/java/webpayplus/WebpayModalTest.java
@@ -58,10 +58,8 @@ public class WebpayModalTest extends TestBase {
     @Test
     public void create() throws IOException, TransactionCreateException {
 
-        
         String url = String.format("/%s/transactions", apiUrl);
 
-        String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
         Map<String, Object> mapResponse = new HashMap<String, Object>();
         mapResponse.put(ApiConstants.TOKEN_TEXT, testToken);
 
@@ -69,12 +67,11 @@ public class WebpayModalTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String sessionId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        double amount = 1000;
-        String returnUrl = "http://wwww.google.com";
+        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String sessionId3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        double amount3 = 1000;
 
-        final ModalTransactionCreateResponse response = (new WebpayPlusModal.Transaction(option)).create(buyOrder, sessionId, amount);
+        final ModalTransactionCreateResponse response = (new WebpayPlusModal.Transaction(option)).create(buyOrder3, sessionId3, amount3);
         assertEquals(testToken, response.getToken());
     }
 
@@ -131,7 +128,7 @@ public class WebpayModalTest extends TestBase {
         
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
 
-        double amount = 1000d;
+        double amount3 = 1000d;
         String type = "REVERSED";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
@@ -141,7 +138,7 @@ public class WebpayModalTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final ModalTransactionRefundResponse response = (new WebpayPlusModal.Transaction(option)).refund(testToken, amount);
+        final ModalTransactionRefundResponse response = (new WebpayPlusModal.Transaction(option)).refund(testToken, amount3);
         assertEquals(type, response.getType());
 
     }

--- a/src/test/java/webpayplus/WebpayModalTest.java
+++ b/src/test/java/webpayplus/WebpayModalTest.java
@@ -1,6 +1,11 @@
 package webpayplus;
 
 import cl.transbank.common.ApiConstants;
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.common.IntegrationType;
+import cl.transbank.model.Options;
+import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.*;
 import cl.transbank.webpay.modal.WebpayPlusModal;
 import cl.transbank.webpay.modal.responses.*;
@@ -21,7 +26,8 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 public class WebpayModalTest extends TestBase {
 
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
-
+    private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS_MODAL,
+            IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
     private static String vci = "TSY";
     private static double amount = 1000d;
     private static String status = "AUTHORIZED";
@@ -52,7 +58,7 @@ public class WebpayModalTest extends TestBase {
     @Test
     public void create() throws IOException, TransactionCreateException {
 
-        WebpayPlusModal.configureForMock();
+        
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -68,7 +74,7 @@ public class WebpayModalTest extends TestBase {
         double amount = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        final ModalTransactionCreateResponse response = (new WebpayPlusModal.Transaction()).create(buyOrder, sessionId, amount);
+        final ModalTransactionCreateResponse response = (new WebpayPlusModal.Transaction(option)).create(buyOrder, sessionId, amount);
         assertEquals(testToken, response.getToken());
     }
 
@@ -96,14 +102,14 @@ public class WebpayModalTest extends TestBase {
 
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        WebpayPlusModal.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponsePut(url, gson.toJson(mapResponse));
 
-        final ModalTransactionCommitResponse response = (new WebpayPlusModal.Transaction()).commit(testToken);
+        final ModalTransactionCommitResponse response = (new WebpayPlusModal.Transaction(option)).commit(testToken);
         assertEquals(vci, response.getVci());
         assertEquals(amount, response.getAmount());
         assertEquals(status, response.getStatus());
@@ -122,7 +128,7 @@ public class WebpayModalTest extends TestBase {
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        WebpayPlusModal.configureForMock();
+        
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
 
         double amount = 1000d;
@@ -135,21 +141,21 @@ public class WebpayModalTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final ModalTransactionRefundResponse response = (new WebpayPlusModal.Transaction()).refund(testToken, amount);
+        final ModalTransactionRefundResponse response = (new WebpayPlusModal.Transaction(option)).refund(testToken, amount);
         assertEquals(type, response.getType());
 
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        WebpayPlusModal.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final ModalTransactionStatusResponse response = (new WebpayPlusModal.Transaction()).status(testToken);
+        final ModalTransactionStatusResponse response = (new WebpayPlusModal.Transaction(option)).status(testToken);
         assertEquals(vci, response.getVci());
         assertEquals(amount, response.getAmount());
         assertEquals(status, response.getStatus());

--- a/src/test/java/webpayplus/WebpayModalTest.java
+++ b/src/test/java/webpayplus/WebpayModalTest.java
@@ -121,7 +121,7 @@ public class WebpayModalTest extends TestBase {
         assertEquals(authorizationCode, response.getAuthorizationCode());
         assertEquals(paymentTypeCode, response.getPaymentTypeCode());
         assertEquals(responseCode, response.getResponseCode());
-        //assertEquals(response.getInstallmentsAmount(), mapResponse.get("amount"));
+        
         assertEquals(installmentsNumber, response.getInstallmentsNumber());
     }
 
@@ -167,7 +167,7 @@ public class WebpayModalTest extends TestBase {
         assertEquals(authorizationCode, response.getAuthorizationCode());
         assertEquals(paymentTypeCode, response.getPaymentTypeCode());
         assertEquals(responseCode, response.getResponseCode());
-        //assertEquals(response.getInstallmentsAmount(), mapResponse.get("amount"));
+        
         assertEquals(installmentsNumber, response.getInstallmentsNumber());
 
     }

--- a/src/test/java/webpayplus/WebpayPlusDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusDeferredTest.java
@@ -23,26 +23,10 @@ import java.util.Random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
-public class WebpayPlusDeferredTest extends TestBase {
-
+public class WebpayPlusDeferredTest extends WebpayPlusTestBase {
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
     private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
-    private static String vci = "TSY";
-    private static double amount = 1000d;
-    private static String status = "AUTHORIZED";
-    private static String buyOrder = "1643997337";
-    private static String sessionId = "1134425622";
-    private static String cardNumber = "6623";
-    private static String accountingDate = "0731";
-    private static String transactionDate = "2021-07-31T23:31:14.249Z";
-    private static String authorizationCode = "1213";
-    private static String paymentTypeCode = "VN";
-    private static byte responseCode = 0;
-    private static double installmentsAmount;
-    private static byte installmentsNumber = 0;
-    private static double balance;
-
     private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
@@ -57,7 +41,6 @@ public class WebpayPlusDeferredTest extends TestBase {
 
     @Test
     public void create() throws IOException, TransactionCreateException {
-
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -69,83 +52,41 @@ public class WebpayPlusDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String sessionId3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        double amount3 = 1000;
+        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String sessionId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        double amount = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder3, sessionId3, amount3, returnUrl);
+        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
         assertEquals(testToken, response.getToken());
         assertEquals(urlResponse, response.getUrl());
     }
 
-    private Map<String, Object> generateCommitJsonResponse(){
-
-        Map<String, String> mapResponseDetail = new HashMap<String, String>();
-        mapResponseDetail.put("card_number", cardNumber);
-
-        Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("vci", vci);
-        mapResponse.put("amount", amount);
-        mapResponse.put("status", status);
-        mapResponse.put("buy_order", buyOrder);
-        mapResponse.put("session_id", sessionId);
-        mapResponse.put("card_detail", mapResponseDetail);
-        mapResponse.put("accounting_date", accountingDate);
-        mapResponse.put("transaction_date", transactionDate);
-        mapResponse.put("authorization_code", authorizationCode);
-        mapResponse.put("payment_type_code", paymentTypeCode);
-        mapResponse.put("response_code", responseCode);
-        mapResponse.put("installments_number", installmentsNumber);
-
-        return mapResponse;
-    }
-
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        
+        WebpayPlusTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
-
-        String vci3 = "TSY";
-        double amount3 = 1000d;
-        String status3 = "AUTHORIZED";
-        String buyOrder3 = "1643997337";
-        String sessionId3 = "1134425622";
-        String cardNumber3 = "6623";
-        String accountingDate3 = "0731";
-        String transactionDate3 = "2021-07-31T23:31:14.249Z";
-        String authorizationCode3 = "1213";
-        String paymentTypeCode3 = "VN";
-        byte responseCode3 = 0;
-        byte installmentsNumber3 = 0;
-
-        Map<String, Object> mapResponse = generateCommitJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponsePut(url, gson.toJson(mapResponse));
+        setResponsePut(url, generateCommitJsonResponse());
 
         final WebpayPlusTransactionCommitResponse response = (new WebpayPlus.Transaction(option)).commit(testToken);
-        assertEquals(vci3, response.getVci());
-        assertEquals(amount3, response.getAmount());
-        assertEquals(status3, response.getStatus());
-        assertEquals(buyOrder3, response.getBuyOrder());
-        assertEquals(sessionId3, response.getSessionId());
-        assertEquals(cardNumber3, response.getCardDetail().getCardNumber());
-        assertEquals(accountingDate3, response.getAccountingDate());
-        assertEquals(transactionDate3, response.getTransactionDate());
-        assertEquals(authorizationCode3, response.getAuthorizationCode());
-        assertEquals(paymentTypeCode3, response.getPaymentTypeCode());
-        assertEquals(responseCode3, response.getResponseCode());
-        
-        assertEquals(installmentsNumber3, response.getInstallmentsNumber());
+        assertEquals(expectedResponse.getVci(), response.getVci());
+        assertEquals(expectedResponse.getAmount(), response.getAmount());
+        assertEquals(expectedResponse.getStatus(), response.getStatus());
+        assertEquals(expectedResponse.getBuyOrder(), response.getBuyOrder());
+        assertEquals(expectedResponse.getSessionId(), response.getSessionId());
+        assertEquals(expectedResponse.getCardDetail().getCardNumber(), response.getCardDetail().getCardNumber());
+        assertEquals(expectedResponse.getAccountingDate(), response.getAccountingDate());
+        assertEquals(expectedResponse.getTransactionDate(), response.getTransactionDate());
+        assertEquals(expectedResponse.getAuthorizationCode(), response.getAuthorizationCode());
+        assertEquals(expectedResponse.getPaymentTypeCode(), response.getPaymentTypeCode());
+        assertEquals(expectedResponse.getResponseCode(), response.getResponseCode());
+        assertEquals(expectedResponse.getInstallmentsNumber(), response.getInstallmentsNumber());
     }
-
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
-
-        double amount3 = 1000d;
+        double amount = 1000d;
         String type = "REVERSED";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
@@ -155,64 +96,58 @@ public class WebpayPlusDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount3);
-        assertEquals(response.getType(), type);
-
+        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount);
+        assertEquals(type, response.getType());
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        
+        WebpayPlusTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
-
-        Map<String, Object> mapResponse = generateCommitJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponseGet(url, gson.toJson(mapResponse));
+        setResponseGet(url, generateCommitJsonResponse());
 
         final WebpayPlusTransactionStatusResponse response = (new WebpayPlus.Transaction(option)).status(testToken);
-        assertEquals(vci, response.getVci());
-        assertEquals(amount, response.getAmount());
-        assertEquals(status, response.getStatus());
-        assertEquals(buyOrder, response.getBuyOrder());
-        assertEquals(sessionId, response.getSessionId());
-        assertEquals(cardNumber, response.getCardDetail().getCardNumber());
-        assertEquals(accountingDate, response.getAccountingDate());
-        assertEquals(transactionDate, response.getTransactionDate());
-        assertEquals(authorizationCode, response.getAuthorizationCode());
-        assertEquals(paymentTypeCode, response.getPaymentTypeCode());
-        assertEquals(responseCode, response.getResponseCode());
-        
-        assertEquals(installmentsNumber, response.getInstallmentsNumber());
+        assertEquals(expectedResponse.getVci(), response.getVci());
+        assertEquals(expectedResponse.getAmount(), response.getAmount());
+        assertEquals(expectedResponse.getStatus(), response.getStatus());
+        assertEquals(expectedResponse.getBuyOrder(), response.getBuyOrder());
+        assertEquals(expectedResponse.getSessionId(), response.getSessionId());
+        assertEquals(expectedResponse.getCardDetail().getCardNumber(), response.getCardDetail().getCardNumber());
+        assertEquals(expectedResponse.getAccountingDate(), response.getAccountingDate());
+        assertEquals(expectedResponse.getTransactionDate(), response.getTransactionDate());
+        assertEquals(expectedResponse.getAuthorizationCode(), response.getAuthorizationCode());
+        assertEquals(expectedResponse.getPaymentTypeCode(), response.getPaymentTypeCode());
+        assertEquals(expectedResponse.getResponseCode(), response.getResponseCode());
+        assertEquals(expectedResponse.getInstallmentsNumber(), response.getInstallmentsNumber());
     }
 
     @Test
     public void capture() throws IOException, TransactionCaptureException {
-        
         String url = String.format("/%s/transactions/%s/capture", apiUrl, testToken);
-
-        String authorizationCode3 = "1213";
-        String authorizationDate3 = "2021-08-01T03:17:42.785Z";
+        String authorizationCode = "1213";
+        String authorizationDate = "2021-08-01T03:17:42.785Z";
         double capturedAmount = 1000.0;
-        byte responseCode3 = 0;
+        byte responseCode = 0;
+
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("authorization_code", authorizationCode3);
-        mapResponse.put("authorization_date", authorizationDate3);
+        mapResponse.put("authorization_code", authorizationCode);
+        mapResponse.put("authorization_date", authorizationDate);
         mapResponse.put("captured_amount", capturedAmount);
-        mapResponse.put("response_code", responseCode3);
+        mapResponse.put("response_code", responseCode);
 
         Gson gson = new GsonBuilder().create();
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String authorization3 = "1213";
-        double amount3 = 1000;
+        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String authorization = "1213";
+        double amount = 1000;
 
-        final WebpayPlusTransactionCaptureResponse response = (new WebpayPlus.Transaction(option)).capture(testToken, buyOrder3, authorization3, amount3);
-        assertEquals(authorizationCode3, response.getAuthorizationCode());
-        assertEquals(authorizationDate3, response.getAuthorizationDate());
+        final WebpayPlusTransactionCaptureResponse response = (new WebpayPlus.Transaction(option)).capture(testToken, buyOrder, authorization, amount);
+        assertEquals(authorizationCode, response.getAuthorizationCode());
+        assertEquals(authorizationDate, response.getAuthorizationDate());
         assertEquals(capturedAmount, response.getCapturedAmount());
-        assertEquals(responseCode3, response.getResponseCode());
+        assertEquals(responseCode, response.getResponseCode());
     }
 
 }

--- a/src/test/java/webpayplus/WebpayPlusDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusDeferredTest.java
@@ -141,7 +141,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         assertEquals(authorizationCode, response.getAuthorizationCode());
         assertEquals(paymentTypeCode, response.getPaymentTypeCode());
         assertEquals(responseCode, response.getResponseCode());
-        //assertEquals(response.getInstallmentsAmount(), mapResponse.get("amount"));
+        
         assertEquals(installmentsNumber, response.getInstallmentsNumber());
     }
 
@@ -187,7 +187,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         assertEquals(authorizationCode, response.getAuthorizationCode());
         assertEquals(paymentTypeCode, response.getPaymentTypeCode());
         assertEquals(responseCode, response.getResponseCode());
-        //assertEquals(response.getInstallmentsAmount(), mapResponse.get("amount"));
+        
         assertEquals(installmentsNumber, response.getInstallmentsNumber());
     }
 

--- a/src/test/java/webpayplus/WebpayPlusDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusDeferredTest.java
@@ -57,8 +57,7 @@ public class WebpayPlusDeferredTest extends TestBase {
 
     @Test
     public void create() throws IOException, TransactionCreateException {
-        //WebpayPlus.Transaction.setIntegrationType(IntegrationType.SERVER_MOCK);
-        
+
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -70,12 +69,12 @@ public class WebpayPlusDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String sessionId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        double amount = 1000;
+        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String sessionId3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        double amount3 = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
+        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder3, sessionId3, amount3, returnUrl);
         assertEquals(testToken, response.getToken());
         assertEquals(urlResponse, response.getUrl());
     }
@@ -107,17 +106,17 @@ public class WebpayPlusDeferredTest extends TestBase {
         
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
-        String vci = "TSY";
-        double amount = 1000d;
-        String status = "AUTHORIZED";
-        String buyOrder = "1643997337";
-        String sessionId = "1134425622";
-        String cardNumber = "6623";
-        String accountingDate = "0731";
-        String transactionDate = "2021-07-31T23:31:14.249Z";
-        String authorizationCode = "1213";
-        String paymentTypeCode = "VN";
-        byte responseCode = 0;
+        String vci3 = "TSY";
+        double amount3 = 1000d;
+        String status3 = "AUTHORIZED";
+        String buyOrder3 = "1643997337";
+        String sessionId3 = "1134425622";
+        String cardNumber3 = "6623";
+        String accountingDate3 = "0731";
+        String transactionDate3 = "2021-07-31T23:31:14.249Z";
+        String authorizationCode3 = "1213";
+        String paymentTypeCode3 = "VN";
+        byte responseCode3 = 0;
         double installmentsAmount;
         byte installmentsNumber = 0;
         double balance;
@@ -126,21 +125,18 @@ public class WebpayPlusDeferredTest extends TestBase {
         Gson gson = new GsonBuilder().create();
         setResponsePut(url, gson.toJson(mapResponse));
 
-        //System.out.println("jsonResponse: " + jsonResponse);
-        //System.out.println("url: " + url);
-
         final WebpayPlusTransactionCommitResponse response = (new WebpayPlus.Transaction(option)).commit(testToken);
-        assertEquals(vci, response.getVci());
-        assertEquals(amount, response.getAmount());
-        assertEquals(status, response.getStatus());
-        assertEquals(buyOrder, response.getBuyOrder());
-        assertEquals(sessionId, response.getSessionId());
-        assertEquals(cardNumber, response.getCardDetail().getCardNumber());
-        assertEquals(accountingDate, response.getAccountingDate());
-        assertEquals(transactionDate, response.getTransactionDate());
-        assertEquals(authorizationCode, response.getAuthorizationCode());
-        assertEquals(paymentTypeCode, response.getPaymentTypeCode());
-        assertEquals(responseCode, response.getResponseCode());
+        assertEquals(vci3, response.getVci());
+        assertEquals(amount3, response.getAmount());
+        assertEquals(status3, response.getStatus());
+        assertEquals(buyOrder3, response.getBuyOrder());
+        assertEquals(sessionId3, response.getSessionId());
+        assertEquals(cardNumber3, response.getCardDetail().getCardNumber());
+        assertEquals(accountingDate3, response.getAccountingDate());
+        assertEquals(transactionDate3, response.getTransactionDate());
+        assertEquals(authorizationCode3, response.getAuthorizationCode());
+        assertEquals(paymentTypeCode3, response.getPaymentTypeCode());
+        assertEquals(responseCode3, response.getResponseCode());
         
         assertEquals(installmentsNumber, response.getInstallmentsNumber());
     }

--- a/src/test/java/webpayplus/WebpayPlusDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusDeferredTest.java
@@ -1,6 +1,11 @@
 package webpayplus;
 
 import cl.transbank.common.ApiConstants;
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.common.IntegrationType;
+import cl.transbank.model.Options;
+import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.*;
 import cl.transbank.webpay.webpayplus.WebpayPlus;
 import cl.transbank.webpay.webpayplus.responses.*;
@@ -21,7 +26,8 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 public class WebpayPlusDeferredTest extends TestBase {
 
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
-
+    private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS_DEFERRED,
+            IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
     private static String vci = "TSY";
     private static double amount = 1000d;
     private static String status = "AUTHORIZED";
@@ -52,7 +58,7 @@ public class WebpayPlusDeferredTest extends TestBase {
     @Test
     public void create() throws IOException, TransactionCreateException {
         //WebpayPlus.Transaction.setIntegrationType(IntegrationType.SERVER_MOCK);
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -69,7 +75,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         double amount = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction()).create(buyOrder, sessionId, amount, returnUrl);
+        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
         assertEquals(testToken, response.getToken());
         assertEquals(urlResponse, response.getUrl());
     }
@@ -98,7 +104,7 @@ public class WebpayPlusDeferredTest extends TestBase {
 
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         String vci = "TSY";
@@ -123,7 +129,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         //System.out.println("jsonResponse: " + jsonResponse);
         //System.out.println("url: " + url);
 
-        final WebpayPlusTransactionCommitResponse response = (new WebpayPlus.Transaction()).commit(testToken);
+        final WebpayPlusTransactionCommitResponse response = (new WebpayPlus.Transaction(option)).commit(testToken);
         assertEquals(vci, response.getVci());
         assertEquals(amount, response.getAmount());
         assertEquals(status, response.getStatus());
@@ -142,7 +148,7 @@ public class WebpayPlusDeferredTest extends TestBase {
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
 
         double amount = 1000d;
@@ -155,21 +161,21 @@ public class WebpayPlusDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction()).refund(testToken, amount);
+        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount);
         assertEquals(response.getType(), type);
 
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final WebpayPlusTransactionStatusResponse response = (new WebpayPlus.Transaction()).status(testToken);
+        final WebpayPlusTransactionStatusResponse response = (new WebpayPlus.Transaction(option)).status(testToken);
         assertEquals(vci, response.getVci());
         assertEquals(amount, response.getAmount());
         assertEquals(status, response.getStatus());
@@ -187,7 +193,7 @@ public class WebpayPlusDeferredTest extends TestBase {
 
     @Test
     public void capture() throws IOException, TransactionCaptureException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s/capture", apiUrl, testToken);
 
         String authorizationCode = "1213";
@@ -208,7 +214,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         String authorization = "1213";
         double amount = 1000;
 
-        final WebpayPlusTransactionCaptureResponse response = (new WebpayPlus.Transaction()).capture(testToken, buyOrder, authorization, amount);
+        final WebpayPlusTransactionCaptureResponse response = (new WebpayPlus.Transaction(option)).capture(testToken, buyOrder, authorization, amount);
         assertEquals(authorizationCode, response.getAuthorizationCode());
         assertEquals(authorizationDate, response.getAuthorizationDate());
         assertEquals(capturedAmount, response.getCapturedAmount());

--- a/src/test/java/webpayplus/WebpayPlusDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusDeferredTest.java
@@ -117,9 +117,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         String authorizationCode3 = "1213";
         String paymentTypeCode3 = "VN";
         byte responseCode3 = 0;
-        double installmentsAmount;
-        byte installmentsNumber = 0;
-        double balance;
+        byte installmentsNumber3 = 0;
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
@@ -138,7 +136,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         assertEquals(paymentTypeCode3, response.getPaymentTypeCode());
         assertEquals(responseCode3, response.getResponseCode());
         
-        assertEquals(installmentsNumber, response.getInstallmentsNumber());
+        assertEquals(installmentsNumber3, response.getInstallmentsNumber());
     }
 
 
@@ -147,7 +145,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
 
-        double amount = 1000d;
+        double amount3 = 1000d;
         String type = "REVERSED";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
@@ -157,7 +155,7 @@ public class WebpayPlusDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount);
+        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount3);
         assertEquals(response.getType(), type);
 
     }
@@ -192,13 +190,13 @@ public class WebpayPlusDeferredTest extends TestBase {
         
         String url = String.format("/%s/transactions/%s/capture", apiUrl, testToken);
 
-        String authorizationCode = "1213";
-        String authorizationDate = "2021-08-01T03:17:42.785Z";
+        String authorizationCode3 = "1213";
+        String authorizationDate3 = "2021-08-01T03:17:42.785Z";
         double capturedAmount = 1000.0;
         byte responseCode = 0;
         Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("authorization_code", authorizationCode);
-        mapResponse.put("authorization_date", authorizationDate);
+        mapResponse.put("authorization_code", authorizationCode3);
+        mapResponse.put("authorization_date", authorizationDate3);
         mapResponse.put("captured_amount", capturedAmount);
         mapResponse.put("response_code", responseCode);
 
@@ -211,8 +209,8 @@ public class WebpayPlusDeferredTest extends TestBase {
         double amount = 1000;
 
         final WebpayPlusTransactionCaptureResponse response = (new WebpayPlus.Transaction(option)).capture(testToken, buyOrder, authorization, amount);
-        assertEquals(authorizationCode, response.getAuthorizationCode());
-        assertEquals(authorizationDate, response.getAuthorizationDate());
+        assertEquals(authorizationCode3, response.getAuthorizationCode());
+        assertEquals(authorizationDate3, response.getAuthorizationDate());
         assertEquals(capturedAmount, response.getCapturedAmount());
         assertEquals(responseCode, response.getResponseCode());
     }

--- a/src/test/java/webpayplus/WebpayPlusDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusDeferredTest.java
@@ -193,26 +193,26 @@ public class WebpayPlusDeferredTest extends TestBase {
         String authorizationCode3 = "1213";
         String authorizationDate3 = "2021-08-01T03:17:42.785Z";
         double capturedAmount = 1000.0;
-        byte responseCode = 0;
+        byte responseCode3 = 0;
         Map<String, Object> mapResponse = new HashMap<String, Object>();
         mapResponse.put("authorization_code", authorizationCode3);
         mapResponse.put("authorization_date", authorizationDate3);
         mapResponse.put("captured_amount", capturedAmount);
-        mapResponse.put("response_code", responseCode);
+        mapResponse.put("response_code", responseCode3);
 
         Gson gson = new GsonBuilder().create();
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String authorization = "1213";
-        double amount = 1000;
+        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String authorization3 = "1213";
+        double amount3 = 1000;
 
-        final WebpayPlusTransactionCaptureResponse response = (new WebpayPlus.Transaction(option)).capture(testToken, buyOrder, authorization, amount);
+        final WebpayPlusTransactionCaptureResponse response = (new WebpayPlus.Transaction(option)).capture(testToken, buyOrder3, authorization3, amount3);
         assertEquals(authorizationCode3, response.getAuthorizationCode());
         assertEquals(authorizationDate3, response.getAuthorizationDate());
         assertEquals(capturedAmount, response.getCapturedAmount());
-        assertEquals(responseCode, response.getResponseCode());
+        assertEquals(responseCode3, response.getResponseCode());
     }
 
 }

--- a/src/test/java/webpayplus/WebpayPlusMallDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusMallDeferredTest.java
@@ -80,8 +80,8 @@ public class WebpayPlusMallDeferredTest extends TestBase {
         setResponsePost(url, jsonResponse);
         String returnUrl = "http://wwww.google.com";
 
-        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String sessionId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String sessionId3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
 
         String buyOrderMallOne = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
         double amountMallOne = 1000;
@@ -95,7 +95,7 @@ public class WebpayPlusMallDeferredTest extends TestBase {
                 .add(amountMallOne, mallOneCommerceCode, buyOrderMallOne)
                 .add(amountMallTwo, mallTwoCommerceCode, buyOrderMallTwo);
 
-        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction(option)).create(buyOrder,sessionId, returnUrl, mallDetails);
+        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction(option)).create(buyOrder3,sessionId3, returnUrl, mallDetails);
         assertEquals(response.getToken(), testToken);
         assertEquals(response.getUrl(), urlResponse);
     }

--- a/src/test/java/webpayplus/WebpayPlusMallDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusMallDeferredTest.java
@@ -21,39 +21,11 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
-public class WebpayPlusMallDeferredTest extends TestBase {
+public class WebpayPlusMallDeferredTest extends WebpayPlusMallTestBase {
 
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
     private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
-    private static String vci = "TSY";
-    private static String buyOrder = "1759488117";
-    private static String sessionId = "777265108";
-    private static String cardNumber = "6623";
-    private static String accountingDate = "0801";
-    private static String transactionDate = "2021-08-01T04:14:09.053Z";
-
-    //details 1
-    private static double amount1 = 1000d;
-    private static String status1 = "AUTHORIZED";
-    private static String authorizationCode1 = "1213";
-    private static String paymentTypeCode1 = "VN";
-    private static byte responseCode1 = 0;
-    private static double installmentsAmount1;
-    private static byte installmentsNumber1 = 0;
-    private static String commerceCode1 = "597055555536";
-    private static String buyOrder1 = "500894028";
-    //details 2
-    private static double amount2 = 1000d;
-    private static String status2 = "AUTHORIZED";
-    private static String authorizationCode2 = "1213";
-    private static String paymentTypeCode2 = "VN";
-    private static byte responseCode2 = 0;
-    private static double installmentsAmount2;
-    private static byte installmentsNumber2 = 0;
-    private static String commerceCode2 = "597055555537";
-    private static String buyOrder2 = "1936357040";
-
     private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
@@ -68,6 +40,7 @@ public class WebpayPlusMallDeferredTest extends TestBase {
 
     @Test
     public void create() throws IOException, TransactionCreateException {
+
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -95,91 +68,53 @@ public class WebpayPlusMallDeferredTest extends TestBase {
                 .add(amountMallOne, mallOneCommerceCode, buyOrderMallOne)
                 .add(amountMallTwo, mallTwoCommerceCode, buyOrderMallTwo);
 
-        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction(option)).create(buyOrder3,sessionId3, returnUrl, mallDetails);
+        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction(option)).create(buyOrder3, sessionId3, returnUrl, mallDetails);
         assertEquals(response.getToken(), testToken);
         assertEquals(response.getUrl(), urlResponse);
     }
 
-    private Map<String, Object> generateCommitJsonResponse(){
-
-        Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
-        mapResponseCardDetail.put("card_number", cardNumber);
-
-        Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
-        mapResponseDetail1.put("amount", amount1);
-        mapResponseDetail1.put("status", status1);
-        mapResponseDetail1.put("authorization_code", authorizationCode1);
-        mapResponseDetail1.put("payment_type_code", paymentTypeCode1);
-        mapResponseDetail1.put("response_code", responseCode1);
-        mapResponseDetail1.put("installments_number", installmentsNumber1);
-        mapResponseDetail1.put("commerce_code", commerceCode1);
-        mapResponseDetail1.put("buy_order", buyOrder1);
-
-        Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
-        mapResponseDetail2.put("amount", amount2);
-        mapResponseDetail2.put("status", status2);
-        mapResponseDetail2.put("authorization_code", authorizationCode2);
-        mapResponseDetail2.put("payment_type_code", paymentTypeCode2);
-        mapResponseDetail2.put("response_code", responseCode2);
-        mapResponseDetail2.put("installments_number", installmentsNumber2);
-        mapResponseDetail2.put("commerce_code", commerceCode2);
-        mapResponseDetail2.put("buy_order", buyOrder2);
-
-        Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("vci", vci);
-        mapResponse.put("buy_order", buyOrder);
-        mapResponse.put("session_id", sessionId);
-        mapResponse.put("card_detail", mapResponseCardDetail);
-        mapResponse.put("accounting_date", accountingDate);
-        mapResponse.put("transaction_date", transactionDate);
-        //details
-        List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
-        lstDetail.add(mapResponseDetail1);
-        lstDetail.add(mapResponseDetail2);
-        mapResponse.put("details", lstDetail);
-
-        return mapResponse;
-    }
-
     @Test
     public void commit() throws IOException, TransactionCommitException {
+        WebpayPlusMallTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
-
-        Map<String, Object> mapResponse = generateCommitJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponsePut(url, gson.toJson(mapResponse));
+        setResponsePut(url, generateCommitJsonResponse());
 
         final WebpayPlusMallTransactionCommitResponse response = (new WebpayPlus.MallTransaction(option)).commit(testToken);
 
-        assertEquals(response.getVci(), vci);
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getSessionId(), sessionId);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getVci(), expectedResponse.getVci());
+        assertEquals(response.getBuyOrder(), expectedResponse.getBuyOrder());
+        assertEquals(response.getSessionId(), expectedResponse.getSessionId());
+        assertEquals(response.getCardDetail().getCardNumber(), expectedResponse.getCardDetail().getCardNumber());
+        assertEquals(response.getAccountingDate(), expectedResponse.getAccountingDate());
+        assertEquals(response.getTransactionDate(), expectedResponse.getTransactionDate());
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        WebpayPlusMallTransactionStatusResponse.Detail expectedDetail1 = expectedResponse.getDetails().get(0);
+        WebpayPlusMallTransactionStatusResponse.Detail detail1 = response.getDetails().get(0);
+        assertEquals(detail1.getAmount(), expectedDetail1.getAmount());
+        assertEquals(detail1.getStatus(), expectedDetail1.getStatus());
+        assertEquals(detail1.getAuthorizationCode(), expectedDetail1.getAuthorizationCode());
+        assertEquals(detail1.getPaymentTypeCode(), expectedDetail1.getPaymentTypeCode());
+        assertEquals(detail1.getResponseCode(), expectedDetail1.getResponseCode());
+        assertEquals(detail1.getInstallmentsNumber(), expectedDetail1.getInstallmentsNumber());
+        assertEquals(detail1.getCommerceCode(), expectedDetail1.getCommerceCode());
+        assertEquals(detail1.getBuyOrder(), expectedDetail1.getBuyOrder());
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        WebpayPlusMallTransactionStatusResponse.Detail expectedDetail2 = expectedResponse.getDetails().get(1);
+        WebpayPlusMallTransactionStatusResponse.Detail detail2 = response.getDetails().get(1);
+        assertEquals(detail2.getAmount(), expectedDetail2.getAmount());
+        assertEquals(detail2.getStatus(), expectedDetail2.getStatus());
+        assertEquals(detail2.getAuthorizationCode(), expectedDetail2.getAuthorizationCode());
+        assertEquals(detail2.getPaymentTypeCode(), expectedDetail2.getPaymentTypeCode());
+        assertEquals(detail2.getResponseCode(), expectedDetail2.getResponseCode());
+        assertEquals(detail2.getInstallmentsNumber(), expectedDetail2.getInstallmentsNumber());
+        assertEquals(detail2.getCommerceCode(), expectedDetail2.getCommerceCode());
+        assertEquals(detail2.getBuyOrder(), expectedDetail2.getBuyOrder());
     }
 
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
+
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
         String type = "REVERSED";
 
@@ -201,45 +136,48 @@ public class WebpayPlusMallDeferredTest extends TestBase {
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        String url = String.format("/%s/transactions/%s", apiUrl, testToken);
-
-        Map<String, Object> mapResponse = generateCommitJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponseGet(url, gson.toJson(mapResponse));
+        WebpayPlusMallTransactionStatusResponse expectedResponse = generateStatusResponse();
+        String url = String.format("/%s/transactions/%s",apiUrl, testToken);
+        setResponseGet(url, generateCommitJsonResponse());
 
         final WebpayPlusMallTransactionStatusResponse response = (new WebpayPlus.MallTransaction(option)).status(testToken);
 
-        assertEquals(response.getVci(), vci);
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getSessionId(), sessionId);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getVci(), expectedResponse.getVci());
+        assertEquals(response.getBuyOrder(), expectedResponse.getBuyOrder());
+        assertEquals(response.getSessionId(), expectedResponse.getSessionId());
+        assertEquals(response.getCardDetail().getCardNumber(), expectedResponse.getCardDetail().getCardNumber());
+        assertEquals(response.getAccountingDate(), expectedResponse.getAccountingDate());
+        assertEquals(response.getTransactionDate(), expectedResponse.getTransactionDate());
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        WebpayPlusMallTransactionStatusResponse.Detail expectedDetail1 = expectedResponse.getDetails().get(0);
+        WebpayPlusMallTransactionStatusResponse.Detail detail1 = response.getDetails().get(0);
+        assertEquals(detail1.getAmount(), expectedDetail1.getAmount());
+        assertEquals(detail1.getStatus(), expectedDetail1.getStatus());
+        assertEquals(detail1.getAuthorizationCode(), expectedDetail1.getAuthorizationCode());
+        assertEquals(detail1.getPaymentTypeCode(), expectedDetail1.getPaymentTypeCode());
+        assertEquals(detail1.getResponseCode(), expectedDetail1.getResponseCode());
+        assertEquals(detail1.getInstallmentsNumber(), expectedDetail1.getInstallmentsNumber());
+        assertEquals(detail1.getCommerceCode(), expectedDetail1.getCommerceCode());
+        assertEquals(detail1.getBuyOrder(), expectedDetail1.getBuyOrder());
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        WebpayPlusMallTransactionStatusResponse.Detail expectedDetail2 = expectedResponse.getDetails().get(1);
+        WebpayPlusMallTransactionStatusResponse.Detail detail2 = response.getDetails().get(1);
+        assertEquals(detail2.getAmount(), expectedDetail2.getAmount());
+        assertEquals(detail2.getStatus(), expectedDetail2.getStatus());
+        assertEquals(detail2.getAuthorizationCode(), expectedDetail2.getAuthorizationCode());
+        assertEquals(detail2.getPaymentTypeCode(), expectedDetail2.getPaymentTypeCode());
+        assertEquals(detail2.getResponseCode(), expectedDetail2.getResponseCode());
+        assertEquals(detail2.getInstallmentsNumber(), expectedDetail2.getInstallmentsNumber());
+        assertEquals(detail2.getCommerceCode(), expectedDetail2.getCommerceCode());
+        assertEquals(detail2.getBuyOrder(), expectedDetail2.getBuyOrder());
     }
-
 
     @Test
     public void capture() throws IOException, TransactionCaptureException {
         String url = String.format("/%s/transactions/%s/capture", apiUrl, testToken);
 
+        String commerceCode = "597055555537";
+        String buyOrder = "1936357040";
         String authorizationCode = "138248";
         String authorizationDate = "2021-08-01T03:17:42.785Z";
         double capturedAmount = 1000.0;
@@ -254,7 +192,7 @@ public class WebpayPlusMallDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        final WebpayPlusMallTransactionCaptureResponse response = (new WebpayPlus.MallTransaction(option)).capture(commerceCode1, testToken, buyOrder1, authorizationCode1, amount1);
+        final WebpayPlusMallTransactionCaptureResponse response = (new WebpayPlus.MallTransaction(option)).capture(commerceCode, testToken, buyOrder, authorizationCode, capturedAmount);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getAuthorizationDate(), authorizationDate);
         assertEquals(response.getCapturedAmount(), capturedAmount);

--- a/src/test/java/webpayplus/WebpayPlusMallDeferredTest.java
+++ b/src/test/java/webpayplus/WebpayPlusMallDeferredTest.java
@@ -1,8 +1,12 @@
 package webpayplus;
 
 import cl.transbank.common.ApiConstants;
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
 import cl.transbank.common.IntegrationType;
 import cl.transbank.model.MallTransactionCreateDetails;
+import cl.transbank.model.Options;
+import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.*;
 import cl.transbank.webpay.webpayplus.WebpayPlus;
 import cl.transbank.webpay.webpayplus.responses.*;
@@ -20,7 +24,8 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 public class WebpayPlusMallDeferredTest extends TestBase {
 
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
-
+    private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS_MALL_DEFERRED,
+            IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
     private static String vci = "TSY";
     private static String buyOrder = "1759488117";
     private static String sessionId = "777265108";
@@ -63,7 +68,6 @@ public class WebpayPlusMallDeferredTest extends TestBase {
 
     @Test
     public void create() throws IOException, TransactionCreateException {
-        WebpayPlus.configureForMock();
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -91,7 +95,7 @@ public class WebpayPlusMallDeferredTest extends TestBase {
                 .add(amountMallOne, mallOneCommerceCode, buyOrderMallOne)
                 .add(amountMallTwo, mallTwoCommerceCode, buyOrderMallTwo);
 
-        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction()).create(buyOrder,sessionId, returnUrl, mallDetails);
+        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction(option)).create(buyOrder,sessionId, returnUrl, mallDetails);
         assertEquals(response.getToken(), testToken);
         assertEquals(response.getUrl(), urlResponse);
     }
@@ -139,14 +143,13 @@ public class WebpayPlusMallDeferredTest extends TestBase {
 
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        WebpayPlus.configureForMock();
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponsePut(url, gson.toJson(mapResponse));
 
-        final WebpayPlusMallTransactionCommitResponse response = (new WebpayPlus.MallTransaction()).commit(testToken);
+        final WebpayPlusMallTransactionCommitResponse response = (new WebpayPlus.MallTransaction(option)).commit(testToken);
 
         assertEquals(response.getVci(), vci);
         assertEquals(response.getBuyOrder(), buyOrder);
@@ -177,7 +180,6 @@ public class WebpayPlusMallDeferredTest extends TestBase {
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        WebpayPlus.configureForMock();
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
         String type = "REVERSED";
 
@@ -192,21 +194,20 @@ public class WebpayPlusMallDeferredTest extends TestBase {
         String childCommerceCode = "597055555536";
         double amount = 1000d;
 
-        final WebpayPlusMallTransactionRefundResponse response = (new WebpayPlus.MallTransaction()).refund(testToken, childBuyOrder, childCommerceCode, amount);
+        final WebpayPlusMallTransactionRefundResponse response = (new WebpayPlus.MallTransaction(option)).refund(testToken, childBuyOrder, childCommerceCode, amount);
         assertEquals(response.getType(), type);
 
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        WebpayPlus.configureForMock();
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final WebpayPlusMallTransactionStatusResponse response = (new WebpayPlus.MallTransaction()).status(testToken);
+        final WebpayPlusMallTransactionStatusResponse response = (new WebpayPlus.MallTransaction(option)).status(testToken);
 
         assertEquals(response.getVci(), vci);
         assertEquals(response.getBuyOrder(), buyOrder);
@@ -237,7 +238,6 @@ public class WebpayPlusMallDeferredTest extends TestBase {
 
     @Test
     public void capture() throws IOException, TransactionCaptureException {
-        WebpayPlus.configureForMock();
         String url = String.format("/%s/transactions/%s/capture", apiUrl, testToken);
 
         String authorizationCode = "138248";
@@ -254,7 +254,7 @@ public class WebpayPlusMallDeferredTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePut(url, jsonResponse);
 
-        final WebpayPlusMallTransactionCaptureResponse response = (new WebpayPlus.MallTransaction()).capture(commerceCode1, testToken, buyOrder1, authorizationCode1, amount1);
+        final WebpayPlusMallTransactionCaptureResponse response = (new WebpayPlus.MallTransaction(option)).capture(commerceCode1, testToken, buyOrder1, authorizationCode1, amount1);
         assertEquals(response.getAuthorizationCode(), authorizationCode);
         assertEquals(response.getAuthorizationDate(), authorizationDate);
         assertEquals(response.getCapturedAmount(), capturedAmount);

--- a/src/test/java/webpayplus/WebpayPlusMallTest.java
+++ b/src/test/java/webpayplus/WebpayPlusMallTest.java
@@ -1,7 +1,12 @@
 package webpayplus;
 
 import cl.transbank.common.ApiConstants;
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.common.IntegrationType;
 import cl.transbank.model.MallTransactionCreateDetails;
+import cl.transbank.model.Options;
+import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.TransactionCommitException;
 import cl.transbank.webpay.exception.TransactionCreateException;
 import cl.transbank.webpay.exception.TransactionRefundException;
@@ -25,7 +30,8 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 public class WebpayPlusMallTest extends TestBase {
 
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
-
+    private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
+            IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
     private static String vci = "TSY";
     private static String buyOrder = "1759488117";
     private static String sessionId = "777265108";
@@ -68,7 +74,7 @@ public class WebpayPlusMallTest extends TestBase {
 
     @Test
     public void create() throws IOException, TransactionCreateException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -96,7 +102,7 @@ public class WebpayPlusMallTest extends TestBase {
                 .add(amountMallOne, mallOneCommerceCode, buyOrderMallOne)
                 .add(amountMallTwo, mallTwoCommerceCode, buyOrderMallTwo);
 
-        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction()).create(buyOrder, sessionId, returnUrl, mallDetails);
+        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction(option)).create(buyOrder, sessionId, returnUrl, mallDetails);
         assertEquals(response.getToken(), testToken);
         assertEquals(response.getUrl(), urlResponse);
     }
@@ -144,14 +150,14 @@ public class WebpayPlusMallTest extends TestBase {
 
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponsePut(url, gson.toJson(mapResponse));
 
-        final WebpayPlusMallTransactionCommitResponse response = (new WebpayPlus.MallTransaction()).commit(testToken);
+        final WebpayPlusMallTransactionCommitResponse response = (new WebpayPlus.MallTransaction(option)).commit(testToken);
 
         assertEquals(response.getVci(), vci);
         assertEquals(response.getBuyOrder(), buyOrder);
@@ -182,7 +188,7 @@ public class WebpayPlusMallTest extends TestBase {
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
         String type = "REVERSED";
 
@@ -197,21 +203,21 @@ public class WebpayPlusMallTest extends TestBase {
         String childCommerceCode = "597055555536";
         double amount = 1000d;
 
-        final WebpayPlusMallTransactionRefundResponse response = (new WebpayPlus.MallTransaction()).refund(testToken, childBuyOrder, childCommerceCode, amount);
+        final WebpayPlusMallTransactionRefundResponse response = (new WebpayPlus.MallTransaction(option)).refund(testToken, childBuyOrder, childCommerceCode, amount);
         assertEquals(response.getType(), type);
 
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s",apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final WebpayPlusMallTransactionStatusResponse response = (new WebpayPlus.MallTransaction()).status(testToken);
+        final WebpayPlusMallTransactionStatusResponse response = (new WebpayPlus.MallTransaction(option)).status(testToken);
 
         assertEquals(response.getVci(), vci);
         assertEquals(response.getBuyOrder(), buyOrder);

--- a/src/test/java/webpayplus/WebpayPlusMallTest.java
+++ b/src/test/java/webpayplus/WebpayPlusMallTest.java
@@ -12,10 +12,7 @@ import cl.transbank.webpay.exception.TransactionCreateException;
 import cl.transbank.webpay.exception.TransactionRefundException;
 import cl.transbank.webpay.exception.TransactionStatusException;
 import cl.transbank.webpay.webpayplus.WebpayPlus;
-import cl.transbank.webpay.webpayplus.responses.WebpayPlusMallTransactionCommitResponse;
-import cl.transbank.webpay.webpayplus.responses.WebpayPlusMallTransactionCreateResponse;
-import cl.transbank.webpay.webpayplus.responses.WebpayPlusMallTransactionRefundResponse;
-import cl.transbank.webpay.webpayplus.responses.WebpayPlusMallTransactionStatusResponse;
+import cl.transbank.webpay.webpayplus.responses.*;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.AfterAll;
@@ -27,39 +24,11 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
-public class WebpayPlusMallTest extends TestBase {
+public class WebpayPlusMallTest extends WebpayPlusMallTestBase {
 
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
     private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
-    private static String vci = "TSY";
-    private static String buyOrder = "1759488117";
-    private static String sessionId = "777265108";
-    private static String cardNumber = "6623";
-    private static String accountingDate = "0801";
-    private static String transactionDate = "2021-08-01T04:14:09.053Z";
-
-    //details 1
-    private static double amount1 = 1000d;
-    private static String status1 = "AUTHORIZED";
-    private static String authorizationCode1 = "1213";
-    private static String paymentTypeCode1 = "VN";
-    private static byte responseCode1 = 0;
-    private static double installmentsAmount1;
-    private static byte installmentsNumber1 = 0;
-    private static String commerceCode1 = "597055555536";
-    private static String buyOrder1 = "500894028";
-    //details 2
-    private static double amount2 = 1000d;
-    private static String status2 = "AUTHORIZED";
-    private static String authorizationCode2 = "1213";
-    private static String paymentTypeCode2 = "VN";
-    private static byte responseCode2 = 0;
-    private static double installmentsAmount2;
-    private static byte installmentsNumber2 = 0;
-    private static String commerceCode2 = "597055555537";
-    private static String buyOrder2 = "1936357040";
-
     private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
@@ -107,82 +76,42 @@ public class WebpayPlusMallTest extends TestBase {
         assertEquals(response.getUrl(), urlResponse);
     }
 
-    private Map<String, Object> generateCommitJsonResponse(){
-
-        Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
-        mapResponseCardDetail.put("card_number", cardNumber);
-
-        Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
-        mapResponseDetail1.put("amount", amount1);
-        mapResponseDetail1.put("status", status1);
-        mapResponseDetail1.put("authorization_code", authorizationCode1);
-        mapResponseDetail1.put("payment_type_code", paymentTypeCode1);
-        mapResponseDetail1.put("response_code", responseCode1);
-        mapResponseDetail1.put("installments_number", installmentsNumber1);
-        mapResponseDetail1.put("commerce_code", commerceCode1);
-        mapResponseDetail1.put("buy_order", buyOrder1);
-
-        Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
-        mapResponseDetail2.put("amount", amount2);
-        mapResponseDetail2.put("status", status2);
-        mapResponseDetail2.put("authorization_code", authorizationCode2);
-        mapResponseDetail2.put("payment_type_code", paymentTypeCode2);
-        mapResponseDetail2.put("response_code", responseCode2);
-        mapResponseDetail2.put("installments_number", installmentsNumber2);
-        mapResponseDetail2.put("commerce_code", commerceCode2);
-        mapResponseDetail2.put("buy_order", buyOrder2);
-
-        Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("vci", vci);
-        mapResponse.put("buy_order", buyOrder);
-        mapResponse.put("session_id", sessionId);
-        mapResponse.put("card_detail", mapResponseCardDetail);
-        mapResponse.put("accounting_date", accountingDate);
-        mapResponse.put("transaction_date", transactionDate);
-        //details
-        List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
-        lstDetail.add(mapResponseDetail1);
-        lstDetail.add(mapResponseDetail2);
-        mapResponse.put("details", lstDetail);
-
-        return mapResponse;
-    }
-
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        
+        WebpayPlusMallTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
-
-        Map<String, Object> mapResponse = generateCommitJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponsePut(url, gson.toJson(mapResponse));
+        setResponsePut(url, generateCommitJsonResponse());
 
         final WebpayPlusMallTransactionCommitResponse response = (new WebpayPlus.MallTransaction(option)).commit(testToken);
 
-        assertEquals(response.getVci(), vci);
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getSessionId(), sessionId);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getVci(), expectedResponse.getVci());
+        assertEquals(response.getBuyOrder(), expectedResponse.getBuyOrder());
+        assertEquals(response.getSessionId(), expectedResponse.getSessionId());
+        assertEquals(response.getCardDetail().getCardNumber(), expectedResponse.getCardDetail().getCardNumber());
+        assertEquals(response.getAccountingDate(), expectedResponse.getAccountingDate());
+        assertEquals(response.getTransactionDate(), expectedResponse.getTransactionDate());
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        WebpayPlusMallTransactionStatusResponse.Detail expectedDetail1 = expectedResponse.getDetails().get(0);
+        WebpayPlusMallTransactionStatusResponse.Detail detail1 = response.getDetails().get(0);
+        assertEquals(detail1.getAmount(), expectedDetail1.getAmount());
+        assertEquals(detail1.getStatus(), expectedDetail1.getStatus());
+        assertEquals(detail1.getAuthorizationCode(), expectedDetail1.getAuthorizationCode());
+        assertEquals(detail1.getPaymentTypeCode(), expectedDetail1.getPaymentTypeCode());
+        assertEquals(detail1.getResponseCode(), expectedDetail1.getResponseCode());
+        assertEquals(detail1.getInstallmentsNumber(), expectedDetail1.getInstallmentsNumber());
+        assertEquals(detail1.getCommerceCode(), expectedDetail1.getCommerceCode());
+        assertEquals(detail1.getBuyOrder(), expectedDetail1.getBuyOrder());
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        WebpayPlusMallTransactionStatusResponse.Detail expectedDetail2 = expectedResponse.getDetails().get(1);
+        WebpayPlusMallTransactionStatusResponse.Detail detail2 = response.getDetails().get(1);
+        assertEquals(detail2.getAmount(), expectedDetail2.getAmount());
+        assertEquals(detail2.getStatus(), expectedDetail2.getStatus());
+        assertEquals(detail2.getAuthorizationCode(), expectedDetail2.getAuthorizationCode());
+        assertEquals(detail2.getPaymentTypeCode(), expectedDetail2.getPaymentTypeCode());
+        assertEquals(detail2.getResponseCode(), expectedDetail2.getResponseCode());
+        assertEquals(detail2.getInstallmentsNumber(), expectedDetail2.getInstallmentsNumber());
+        assertEquals(detail2.getCommerceCode(), expectedDetail2.getCommerceCode());
+        assertEquals(detail2.getBuyOrder(), expectedDetail2.getBuyOrder());
     }
 
 
@@ -210,39 +139,40 @@ public class WebpayPlusMallTest extends TestBase {
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        
+        WebpayPlusMallTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions/%s",apiUrl, testToken);
-
-        Map<String, Object> mapResponse = generateCommitJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponseGet(url, gson.toJson(mapResponse));
+        setResponseGet(url, generateCommitJsonResponse());
 
         final WebpayPlusMallTransactionStatusResponse response = (new WebpayPlus.MallTransaction(option)).status(testToken);
 
-        assertEquals(response.getVci(), vci);
-        assertEquals(response.getBuyOrder(), buyOrder);
-        assertEquals(response.getSessionId(), sessionId);
-        assertEquals(response.getCardDetail().getCardNumber(), cardNumber);
-        assertEquals(response.getAccountingDate(), accountingDate);
-        assertEquals(response.getTransactionDate(), transactionDate);
+        assertEquals(response.getVci(), expectedResponse.getVci());
+        assertEquals(response.getBuyOrder(), expectedResponse.getBuyOrder());
+        assertEquals(response.getSessionId(), expectedResponse.getSessionId());
+        assertEquals(response.getCardDetail().getCardNumber(), expectedResponse.getCardDetail().getCardNumber());
+        assertEquals(response.getAccountingDate(), expectedResponse.getAccountingDate());
+        assertEquals(response.getTransactionDate(), expectedResponse.getTransactionDate());
         //details1
-        assertEquals(response.getDetails().get(0).getAmount(), amount1);
-        assertEquals(response.getDetails().get(0).getStatus(), status1);
-        assertEquals(response.getDetails().get(0).getAuthorizationCode(), authorizationCode1);
-        assertEquals(response.getDetails().get(0).getPaymentTypeCode(), paymentTypeCode1);
-        assertEquals(response.getDetails().get(0).getResponseCode(), responseCode1);
-        assertEquals(response.getDetails().get(0).getInstallmentsNumber(), installmentsNumber1);
-        assertEquals(response.getDetails().get(0).getCommerceCode(), commerceCode1);
-        assertEquals(response.getDetails().get(0).getBuyOrder(), buyOrder1);
+        WebpayPlusMallTransactionStatusResponse.Detail expectedDetail1 = expectedResponse.getDetails().get(0);
+        WebpayPlusMallTransactionStatusResponse.Detail detail1 = response.getDetails().get(0);
+        assertEquals(detail1.getAmount(), expectedDetail1.getAmount());
+        assertEquals(detail1.getStatus(), expectedDetail1.getStatus());
+        assertEquals(detail1.getAuthorizationCode(), expectedDetail1.getAuthorizationCode());
+        assertEquals(detail1.getPaymentTypeCode(), expectedDetail1.getPaymentTypeCode());
+        assertEquals(detail1.getResponseCode(), expectedDetail1.getResponseCode());
+        assertEquals(detail1.getInstallmentsNumber(), expectedDetail1.getInstallmentsNumber());
+        assertEquals(detail1.getCommerceCode(), expectedDetail1.getCommerceCode());
+        assertEquals(detail1.getBuyOrder(), expectedDetail1.getBuyOrder());
         //details2
-        assertEquals(response.getDetails().get(1).getAmount(), amount2);
-        assertEquals(response.getDetails().get(1).getStatus(), status2);
-        assertEquals(response.getDetails().get(1).getAuthorizationCode(), authorizationCode2);
-        assertEquals(response.getDetails().get(1).getPaymentTypeCode(), paymentTypeCode2);
-        assertEquals(response.getDetails().get(1).getResponseCode(), responseCode2);
-        assertEquals(response.getDetails().get(1).getInstallmentsNumber(), installmentsNumber2);
-        assertEquals(response.getDetails().get(1).getCommerceCode(), commerceCode2);
-        assertEquals(response.getDetails().get(1).getBuyOrder(), buyOrder2);
+        WebpayPlusMallTransactionStatusResponse.Detail expectedDetail2 = expectedResponse.getDetails().get(1);
+        WebpayPlusMallTransactionStatusResponse.Detail detail2 = response.getDetails().get(1);
+        assertEquals(detail2.getAmount(), expectedDetail2.getAmount());
+        assertEquals(detail2.getStatus(), expectedDetail2.getStatus());
+        assertEquals(detail2.getAuthorizationCode(), expectedDetail2.getAuthorizationCode());
+        assertEquals(detail2.getPaymentTypeCode(), expectedDetail2.getPaymentTypeCode());
+        assertEquals(detail2.getResponseCode(), expectedDetail2.getResponseCode());
+        assertEquals(detail2.getInstallmentsNumber(), expectedDetail2.getInstallmentsNumber());
+        assertEquals(detail2.getCommerceCode(), expectedDetail2.getCommerceCode());
+        assertEquals(detail2.getBuyOrder(), expectedDetail2.getBuyOrder());
     }
 
 }

--- a/src/test/java/webpayplus/WebpayPlusMallTest.java
+++ b/src/test/java/webpayplus/WebpayPlusMallTest.java
@@ -87,8 +87,8 @@ public class WebpayPlusMallTest extends TestBase {
         setResponsePost(url, jsonResponse);
         String returnUrl = "http://wwww.google.com";
 
-        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String sessionId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String sessionId3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
 
         String buyOrderMallOne = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
         double amountMallOne = 1000;
@@ -102,7 +102,7 @@ public class WebpayPlusMallTest extends TestBase {
                 .add(amountMallOne, mallOneCommerceCode, buyOrderMallOne)
                 .add(amountMallTwo, mallTwoCommerceCode, buyOrderMallTwo);
 
-        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction(option)).create(buyOrder, sessionId, returnUrl, mallDetails);
+        final WebpayPlusMallTransactionCreateResponse response = (new WebpayPlus.MallTransaction(option)).create(buyOrder3, sessionId3, returnUrl, mallDetails);
         assertEquals(response.getToken(), testToken);
         assertEquals(response.getUrl(), urlResponse);
     }

--- a/src/test/java/webpayplus/WebpayPlusMallTestBase.java
+++ b/src/test/java/webpayplus/WebpayPlusMallTestBase.java
@@ -1,0 +1,62 @@
+package webpayplus;
+
+import cl.transbank.webpay.webpayplus.responses.WebpayPlusMallTransactionStatusResponse;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class WebpayPlusMallTestBase extends TestBase {
+    protected String generateCommitJsonResponse(){
+        Map<String, String> mapResponseCardDetail = new HashMap<String, String>();
+        mapResponseCardDetail.put("card_number", "6623");
+
+        Map<String, Object> mapResponseDetail1 = new HashMap<String, Object>();
+        mapResponseDetail1.put("amount", 1000d);
+        mapResponseDetail1.put("status", "AUTHORIZED");
+        mapResponseDetail1.put("authorization_code", "1213");
+        mapResponseDetail1.put("payment_type_code", "VN");
+        mapResponseDetail1.put("response_code", (byte)0);
+        mapResponseDetail1.put("installments_number", (byte)0);
+        mapResponseDetail1.put("commerce_code", "597055555536");
+        mapResponseDetail1.put("buy_order", "500894028");
+
+        Map<String, Object> mapResponseDetail2 = new HashMap<String, Object>();
+        mapResponseDetail2.put("amount", 2000d);
+        mapResponseDetail2.put("status", "AUTHORIZED");
+        mapResponseDetail2.put("authorization_code", "1213");
+        mapResponseDetail2.put("payment_type_code", "VN");
+        mapResponseDetail2.put("response_code", (byte)0);
+        mapResponseDetail2.put("installments_number", (byte)0);
+        mapResponseDetail2.put("commerce_code", "597055555537");
+        mapResponseDetail2.put("buy_order", "1936357040");
+
+        Map<String, Object> mapResponse = new HashMap<String, Object>();
+        mapResponse.put("vci", "TSY");
+        mapResponse.put("buy_order", "1643997337");
+        mapResponse.put("session_id", "1134425622");
+        mapResponse.put("card_detail", mapResponseCardDetail);
+        mapResponse.put("accounting_date", "0731");
+        mapResponse.put("transaction_date", "2021-07-31T23:31:14.249Z");
+        //details
+        List<Map<String, Object>> lstDetail = new ArrayList<Map<String, Object>>();
+        lstDetail.add(mapResponseDetail1);
+        lstDetail.add(mapResponseDetail2);
+        mapResponse.put("details", lstDetail);
+
+        Gson gson = new GsonBuilder().create();
+        return gson.toJson(mapResponse);
+    }
+    protected WebpayPlusMallTransactionStatusResponse generateStatusResponse() {
+        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+        return gson.fromJson(generateCommitJsonResponse(), WebpayPlusMallTransactionStatusResponse.class);
+    }
+
+
+
+
+
+}

--- a/src/test/java/webpayplus/WebpayPlusTest.java
+++ b/src/test/java/webpayplus/WebpayPlusTest.java
@@ -84,7 +84,9 @@ public class WebpayPlusTest extends TestBase {
         double amount = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
+        //final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
+        WebpayPlus.Transaction transaction = WebpayPlus.Transaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS, IntegrationApiKeys.WEBPAY);
+        final WebpayPlusTransactionCreateResponse response = transaction.create(buyOrder, sessionId, amount, returnUrl);
         assertEquals(testToken, response.getToken());
         assertEquals(urlResponse, response.getUrl());
     }
@@ -132,7 +134,7 @@ public class WebpayPlusTest extends TestBase {
         assertEquals(authorizationCode, response.getAuthorizationCode());
         assertEquals(paymentTypeCode, response.getPaymentTypeCode());
         assertEquals(responseCode, response.getResponseCode());
-        //assertEquals(response.getInstallmentsAmount(), mapResponse.get("amount"));
+        
         assertEquals(installmentsNumber, response.getInstallmentsNumber());
     }
 
@@ -178,7 +180,7 @@ public class WebpayPlusTest extends TestBase {
         assertEquals(authorizationCode, response.getAuthorizationCode());
         assertEquals(paymentTypeCode, response.getPaymentTypeCode());
         assertEquals(responseCode, response.getResponseCode());
-        //assertEquals(response.getInstallmentsAmount(), mapResponse.get("amount"));
+        
         assertEquals(installmentsNumber, response.getInstallmentsNumber());
 
     }

--- a/src/test/java/webpayplus/WebpayPlusTest.java
+++ b/src/test/java/webpayplus/WebpayPlusTest.java
@@ -1,7 +1,12 @@
 package webpayplus;
 
 import cl.transbank.common.ApiConstants;
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.common.IntegrationType;
 import cl.transbank.model.CardDetail;
+import cl.transbank.model.Options;
+import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.TransactionCommitException;
 import cl.transbank.webpay.exception.TransactionCreateException;
 import cl.transbank.webpay.exception.TransactionRefundException;
@@ -29,7 +34,8 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 public class WebpayPlusTest extends TestBase {
 
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
-
+    private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS,
+            IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
     private static String vci = "TSY";
     private static double amount = 1000d;
     private static String status = "AUTHORIZED";
@@ -60,7 +66,7 @@ public class WebpayPlusTest extends TestBase {
     @Test
     public void create() throws IOException, TransactionCreateException {
 
-        WebpayPlus.configureForMock();
+        
         //WebpayPlus.configureForTesting();
         String url = String.format("/%s/transactions", apiUrl);
 
@@ -78,7 +84,7 @@ public class WebpayPlusTest extends TestBase {
         double amount = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction()).create(buyOrder, sessionId, amount, returnUrl);
+        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
         assertEquals(testToken, response.getToken());
         assertEquals(urlResponse, response.getUrl());
     }
@@ -107,14 +113,14 @@ public class WebpayPlusTest extends TestBase {
 
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponsePut(url, gson.toJson(mapResponse));
 
-        final WebpayPlusTransactionCommitResponse response = (new WebpayPlus.Transaction()).commit(testToken);
+        final WebpayPlusTransactionCommitResponse response = (new WebpayPlus.Transaction(option)).commit(testToken);
         assertEquals(vci, response.getVci());
         assertEquals(amount, response.getAmount());
         assertEquals(status, response.getStatus());
@@ -133,7 +139,7 @@ public class WebpayPlusTest extends TestBase {
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
 
         double amount = 1000d;
@@ -146,21 +152,21 @@ public class WebpayPlusTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction()).refund(testToken, amount);
+        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount);
         assertEquals(type, response.getType());
 
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        WebpayPlus.configureForMock();
+        
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
 
         Map<String, Object> mapResponse = generateCommitJsonResponse();
         Gson gson = new GsonBuilder().create();
         setResponseGet(url, gson.toJson(mapResponse));
 
-        final WebpayPlusTransactionStatusResponse response = (new WebpayPlus.Transaction()).status(testToken);
+        final WebpayPlusTransactionStatusResponse response = (new WebpayPlus.Transaction(option)).status(testToken);
         assertEquals(vci, response.getVci());
         assertEquals(amount, response.getAmount());
         assertEquals(status, response.getStatus());

--- a/src/test/java/webpayplus/WebpayPlusTest.java
+++ b/src/test/java/webpayplus/WebpayPlusTest.java
@@ -66,8 +66,6 @@ public class WebpayPlusTest extends TestBase {
     @Test
     public void create() throws IOException, TransactionCreateException {
 
-        
-        //WebpayPlus.configureForTesting();
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -79,12 +77,12 @@ public class WebpayPlusTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String sessionId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        double amount = 1000;
+        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String sessionId3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        double amount3 = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
+        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder3, sessionId3, amount3, returnUrl);
         assertEquals(testToken, response.getToken());
         assertEquals(urlResponse, response.getUrl());
     }

--- a/src/test/java/webpayplus/WebpayPlusTest.java
+++ b/src/test/java/webpayplus/WebpayPlusTest.java
@@ -140,7 +140,7 @@ public class WebpayPlusTest extends TestBase {
         
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
 
-        double amount = 1000d;
+        double amount3 = 1000d;
         String type = "REVERSED";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
@@ -150,7 +150,7 @@ public class WebpayPlusTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount);
+        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount3);
         assertEquals(type, response.getType());
 
     }

--- a/src/test/java/webpayplus/WebpayPlusTest.java
+++ b/src/test/java/webpayplus/WebpayPlusTest.java
@@ -4,7 +4,6 @@ import cl.transbank.common.ApiConstants;
 import cl.transbank.common.IntegrationApiKeys;
 import cl.transbank.common.IntegrationCommerceCodes;
 import cl.transbank.common.IntegrationType;
-import cl.transbank.model.CardDetail;
 import cl.transbank.model.Options;
 import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.TransactionCommitException;
@@ -21,8 +20,6 @@ import com.google.gson.GsonBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,26 +28,10 @@ import java.util.Random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
-public class WebpayPlusTest extends TestBase {
-
+public class WebpayPlusTest extends WebpayPlusTestBase {
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
     private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
-    private static String vci = "TSY";
-    private static double amount = 1000d;
-    private static String status = "AUTHORIZED";
-    private static String buyOrder = "1643997337";
-    private static String sessionId = "1134425622";
-    private static String cardNumber = "6623";
-    private static String accountingDate = "0731";
-    private static String transactionDate = "2021-07-31T23:31:14.249Z";
-    private static String authorizationCode = "1213";
-    private static String paymentTypeCode = "VN";
-    private static byte responseCode = 0;
-    private static double installmentsAmount;
-    private static byte installmentsNumber = 0;
-    private static double balance;
-
     private static String testToken = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     @BeforeAll
@@ -65,7 +46,6 @@ public class WebpayPlusTest extends TestBase {
 
     @Test
     public void create() throws IOException, TransactionCreateException {
-
         String url = String.format("/%s/transactions", apiUrl);
 
         String urlResponse = "https://webpay3gint.transbank.cl/webpayserver/initTransaction";
@@ -77,70 +57,41 @@ public class WebpayPlusTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        String buyOrder3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        String sessionId3 = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-        double amount3 = 1000;
+        String buyOrder = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        String sessionId = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        double amount = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder3, sessionId3, amount3, returnUrl);
+        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
         assertEquals(testToken, response.getToken());
         assertEquals(urlResponse, response.getUrl());
     }
 
-    private Map<String, Object> generateCommitJsonResponse(){
-
-        Map<String, String> mapResponseDetail = new HashMap<String, String>();
-        mapResponseDetail.put("card_number", cardNumber);
-
-        Map<String, Object> mapResponse = new HashMap<String, Object>();
-        mapResponse.put("vci", vci);
-        mapResponse.put("amount", amount);
-        mapResponse.put("status", status);
-        mapResponse.put("buy_order", buyOrder);
-        mapResponse.put("session_id", sessionId);
-        mapResponse.put("card_detail", mapResponseDetail);
-        mapResponse.put("accounting_date", accountingDate);
-        mapResponse.put("transaction_date", transactionDate);
-        mapResponse.put("authorization_code", authorizationCode);
-        mapResponse.put("payment_type_code", paymentTypeCode);
-        mapResponse.put("response_code", responseCode);
-        mapResponse.put("installments_number", installmentsNumber);
-
-        return mapResponse;
-    }
-
     @Test
     public void commit() throws IOException, TransactionCommitException {
-        
+        WebpayPlusTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
-
-        Map<String, Object> mapResponse = generateCommitJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponsePut(url, gson.toJson(mapResponse));
+        setResponsePut(url, generateCommitJsonResponse());
 
         final WebpayPlusTransactionCommitResponse response = (new WebpayPlus.Transaction(option)).commit(testToken);
-        assertEquals(vci, response.getVci());
-        assertEquals(amount, response.getAmount());
-        assertEquals(status, response.getStatus());
-        assertEquals(buyOrder, response.getBuyOrder());
-        assertEquals(sessionId, response.getSessionId());
-        assertEquals(cardNumber, response.getCardDetail().getCardNumber());
-        assertEquals(accountingDate, response.getAccountingDate());
-        assertEquals(transactionDate, response.getTransactionDate());
-        assertEquals(authorizationCode, response.getAuthorizationCode());
-        assertEquals(paymentTypeCode, response.getPaymentTypeCode());
-        assertEquals(responseCode, response.getResponseCode());
-        
-        assertEquals(installmentsNumber, response.getInstallmentsNumber());
+        assertEquals(expectedResponse.getVci(), response.getVci());
+        assertEquals(expectedResponse.getAmount(), response.getAmount());
+        assertEquals(expectedResponse.getStatus(), response.getStatus());
+        assertEquals(expectedResponse.getBuyOrder(), response.getBuyOrder());
+        assertEquals(expectedResponse.getSessionId(), response.getSessionId());
+        assertEquals(expectedResponse.getCardDetail().getCardNumber(), response.getCardDetail().getCardNumber());
+        assertEquals(expectedResponse.getAccountingDate(), response.getAccountingDate());
+        assertEquals(expectedResponse.getTransactionDate(), response.getTransactionDate());
+        assertEquals(expectedResponse.getAuthorizationCode(), response.getAuthorizationCode());
+        assertEquals(expectedResponse.getPaymentTypeCode(), response.getPaymentTypeCode());
+        assertEquals(expectedResponse.getResponseCode(), response.getResponseCode());
+        assertEquals(expectedResponse.getInstallmentsNumber(), response.getInstallmentsNumber());
     }
-
 
     @Test
     public void refund() throws IOException, TransactionRefundException {
-        
         String url = String.format("/%s/transactions/%s/refunds", apiUrl, testToken);
-
-        double amount3 = 1000d;
+        double amount = 1000d;
         String type = "REVERSED";
 
         Map<String, Object> mapResponse = new HashMap<String, Object>();
@@ -150,63 +101,29 @@ public class WebpayPlusTest extends TestBase {
         String jsonResponse = gson.toJson(mapResponse);
         setResponsePost(url, jsonResponse);
 
-        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount3);
+        final WebpayPlusTransactionRefundResponse response = (new WebpayPlus.Transaction(option)).refund(testToken, amount);
         assertEquals(type, response.getType());
-
     }
 
     @Test
     public void status() throws IOException, TransactionStatusException {
-        
+        WebpayPlusTransactionStatusResponse expectedResponse = generateStatusResponse();
         String url = String.format("/%s/transactions/%s", apiUrl, testToken);
-
-        Map<String, Object> mapResponse = generateCommitJsonResponse();
-        Gson gson = new GsonBuilder().create();
-        setResponseGet(url, gson.toJson(mapResponse));
+        setResponseGet(url, generateCommitJsonResponse());
 
         final WebpayPlusTransactionStatusResponse response = (new WebpayPlus.Transaction(option)).status(testToken);
-        assertEquals(vci, response.getVci());
-        assertEquals(amount, response.getAmount());
-        assertEquals(status, response.getStatus());
-        assertEquals(buyOrder, response.getBuyOrder());
-        assertEquals(sessionId, response.getSessionId());
-        assertEquals(cardNumber, response.getCardDetail().getCardNumber());
-        assertEquals(accountingDate, response.getAccountingDate());
-        assertEquals(transactionDate, response.getTransactionDate());
-        assertEquals(authorizationCode, response.getAuthorizationCode());
-        assertEquals(paymentTypeCode, response.getPaymentTypeCode());
-        assertEquals(responseCode, response.getResponseCode());
-        
-        assertEquals(installmentsNumber, response.getInstallmentsNumber());
-
+        assertEquals(expectedResponse.getVci(), response.getVci());
+        assertEquals(expectedResponse.getAmount(), response.getAmount());
+        assertEquals(expectedResponse.getStatus(), response.getStatus());
+        assertEquals(expectedResponse.getBuyOrder(), response.getBuyOrder());
+        assertEquals(expectedResponse.getSessionId(), response.getSessionId());
+        assertEquals(expectedResponse.getCardDetail().getCardNumber(), response.getCardDetail().getCardNumber());
+        assertEquals(expectedResponse.getAccountingDate(), response.getAccountingDate());
+        assertEquals(expectedResponse.getTransactionDate(), response.getTransactionDate());
+        assertEquals(expectedResponse.getAuthorizationCode(), response.getAuthorizationCode());
+        assertEquals(expectedResponse.getPaymentTypeCode(), response.getPaymentTypeCode());
+        assertEquals(expectedResponse.getResponseCode(), response.getResponseCode());
+        assertEquals(expectedResponse.getInstallmentsNumber(), response.getInstallmentsNumber());
     }
-
-    @Test
-    public void prueba1() throws IOException, TransactionStatusException {
-
-        WebpayPlusTransactionStatusResponse r = new WebpayPlusTransactionCommitResponse();
-        r.setVci(vci);
-        r.setAmount(amount);
-        r.setStatus(status);
-        r.setBuyOrder(buyOrder);
-        r.setSessionId(sessionId);
-        r.setCardDetail(new CardDetail());
-        r.getCardDetail().setCardNumber(cardNumber);
-
-
-        WebpayPlus.Transaction tx = Mockito.mock(WebpayPlus.Transaction.class);
-        Mockito.when(tx.status(testToken)).thenReturn(r);
-
-        final WebpayPlusTransactionStatusResponse response = tx.status(testToken);
-        assertEquals(vci, response.getVci());
-        assertEquals(amount, response.getAmount());
-        assertEquals(status, response.getStatus());
-        assertEquals(buyOrder, response.getBuyOrder());
-        assertEquals(sessionId, response.getSessionId());
-        assertEquals(cardNumber, response.getCardDetail().getCardNumber());
-
-    }
-
-
 
 }

--- a/src/test/java/webpayplus/WebpayPlusTest.java
+++ b/src/test/java/webpayplus/WebpayPlusTest.java
@@ -84,9 +84,7 @@ public class WebpayPlusTest extends TestBase {
         double amount = 1000;
         String returnUrl = "http://wwww.google.com";
 
-        //final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
-        WebpayPlus.Transaction transaction = WebpayPlus.Transaction.buildForIntegration(IntegrationCommerceCodes.WEBPAY_PLUS, IntegrationApiKeys.WEBPAY);
-        final WebpayPlusTransactionCreateResponse response = transaction.create(buyOrder, sessionId, amount, returnUrl);
+        final WebpayPlusTransactionCreateResponse response = (new WebpayPlus.Transaction(option)).create(buyOrder, sessionId, amount, returnUrl);
         assertEquals(testToken, response.getToken());
         assertEquals(urlResponse, response.getUrl());
     }

--- a/src/test/java/webpayplus/WebpayPlusTestBase.java
+++ b/src/test/java/webpayplus/WebpayPlusTestBase.java
@@ -1,0 +1,37 @@
+package webpayplus;
+
+import cl.transbank.webpay.webpayplus.responses.WebpayPlusTransactionStatusResponse;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class WebpayPlusTestBase extends TestBase {
+    protected String generateCommitJsonResponse(){
+        Map<String, String> mapResponseDetail = new HashMap<String, String>();
+        mapResponseDetail.put("card_number", "6623");
+
+        Map<String, Object> mapResponse = new HashMap<String, Object>();
+        mapResponse.put("vci", "TSY");
+        mapResponse.put("amount", 1000d);
+        mapResponse.put("status", "AUTHORIZED");
+        mapResponse.put("buy_order", "1643997337");
+        mapResponse.put("session_id", "1134425622");
+        mapResponse.put("card_detail", mapResponseDetail);
+        mapResponse.put("accounting_date", "0731");
+        mapResponse.put("transaction_date", "2021-07-31T23:31:14.249Z");
+        mapResponse.put("authorization_code", "1213");
+        mapResponse.put("payment_type_code", "VD");
+        mapResponse.put("response_code", (byte)0);
+        mapResponse.put("installments_number", (byte)0);
+
+        Gson gson = new GsonBuilder().create();
+        return gson.toJson(mapResponse);
+    }
+    protected WebpayPlusTransactionStatusResponse generateStatusResponse() {
+        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+        return gson.fromJson(generateCommitJsonResponse(), WebpayPlusTransactionStatusResponse.class);
+    }
+
+}


### PR DESCRIPTION
This PR removes the default configuration for integration environment on all products.
Now is necessary use a build method for integration or production environment to create an object.
This is a breaking change, now the integrator must always have control of the environment in which they will use the product, using the corresponding method and credentials.

For example, to create a Webpay Plus Transaction now you must call their corresponding build method.

Integration:
WebpayPlus.Transaction transaction = WebpayPlus.Transaction.buildForIntegration("productionCommerceCode", "productionApiKey");

Production:
WebpayPlus.Transaction transaction = WebpayPlus.Transaction.buildForProduction("productionCommerceCode", "productionApiKey"); 


![image](https://github.com/user-attachments/assets/a1b13d69-7f78-472f-a45a-4df17b50d5af)
![image](https://github.com/user-attachments/assets/a9604a97-d020-4b9e-9123-bbf9dc7b13c0)

