### PR TITLE
TBK-210 feat: refine patpass header

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - master
       - develop
   pull_request:
-    types: [synchronize, opened, reopened]
+    types: [ synchronize, opened, reopened ]
 
 jobs:
   sonar-cloud-check:
@@ -20,8 +20,8 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
-          distribution: 'temurin'
+          java-version: "8"
+          distribution: "temurin"
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
@@ -34,7 +34,7 @@ jobs:
         run: mvn clean install verify -P no-gpg --no-transfer-progress
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@master
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
         with:
           projectBaseDir: .
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Java CI
 
 on:
-  push:
-    branches:
-      - master
-      - develop
   pull_request:
     types: [ synchronize, opened, reopened ]
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.18.0</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/cl/transbank/common/ApiConstants.java
+++ b/src/main/java/cl/transbank/common/ApiConstants.java
@@ -5,14 +5,13 @@ package cl.transbank.common;
  */
 public class ApiConstants {
 
-  public static final String WEBPAY_ENDPOINT =
-    "rswebpaytransaction/api/webpay/v1.2";
-  public static final String ONECLICK_ENDPOINT =
-    "rswebpaytransaction/api/oneclick/v1.2";
-  public static final String PATPASS_COMERCIO_ENDPOINT =
-    "restpatpass/v1/services";
+  public static final String WEBPAY_ENDPOINT = "rswebpaytransaction/api/webpay/v1.2";
+  public static final String ONECLICK_ENDPOINT = "rswebpaytransaction/api/oneclick/v1.2";
+  public static final String PATPASS_COMERCIO_ENDPOINT = "restpatpass/v1/services";
   public static final String HEADER_COMMERCE_CODE_NAME = "Tbk-Api-Key-Id";
   public static final String HEADER_API_KEY_NAME = "Tbk-Api-Key-Secret";
+  public static final String HEADER_PATPASS_COMMERCE_CODE_NAME = "Commercecode";
+  public static final String HEADER_PATPASS_API_KEY_NAME = "Authorization";
   public static final int BUY_ORDER_LENGTH = 26;
   public static final int SESSION_ID_LENGTH = 61;
   public static final int RETURN_URL_LENGTH = 255;

--- a/src/main/java/cl/transbank/util/WebpayApiResource.java
+++ b/src/main/java/cl/transbank/util/WebpayApiResource.java
@@ -7,6 +7,7 @@ import cl.transbank.model.Options;
 import cl.transbank.model.WebpayApiRequest;
 import cl.transbank.webpay.common.WebpayOptions;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
@@ -132,7 +133,7 @@ public abstract class WebpayApiResource {
       final Options options,
       Class<T> clazz) throws TransbankException, IOException {
     RequestContext requestContext = WebpayApiResource.buildRequestContext(options);
-    final URL url = new URL(String.format("%s/%s", requestContext.urlBase, endpoint));
+    final URL url = URI.create(String.format("%s/%s", requestContext.urlBase, endpoint)).toURL();
 
     HttpUtil requestInstance = WebpayApiResource.getHttpUtil();
 
@@ -196,7 +197,7 @@ public abstract class WebpayApiResource {
       final Options options,
       Class<T[]> clazz) throws TransbankException, IOException {
     RequestContext requestContext = WebpayApiResource.buildRequestContext(options);
-    final URL url = new URL(String.format("%s/%s", requestContext.urlBase, endpoint));
+    final URL url = URI.create(String.format("%s/%s", requestContext.urlBase, endpoint)).toURL();
 
     HttpUtil requestInstance = WebpayApiResource.getHttpUtil();
 

--- a/src/main/java/cl/transbank/util/WebpayApiResource.java
+++ b/src/main/java/cl/transbank/util/WebpayApiResource.java
@@ -26,92 +26,112 @@ public abstract class WebpayApiResource {
 
   /**
    * Builds the headers for a Webpay API request.
+   * 
    * @param options The options for the request.
    * @return A map of headers for the request.
    */
   public static Map<String, String> buildHeaders(Options options) {
-    if (null == options) return Collections.emptyMap();
+    if (null == options)
+      return Collections.emptyMap();
 
     Map<String, String> headers = new HashMap<>();
     headers.put(
-      ApiConstants.HEADER_COMMERCE_CODE_NAME,
-      options.getCommerceCode()
-    );
+        ApiConstants.HEADER_COMMERCE_CODE_NAME,
+        options.getCommerceCode());
     headers.put(ApiConstants.HEADER_API_KEY_NAME, options.getApiKey());
 
     return headers;
   }
 
   /**
-   * Executes a Webpay API request.
-   * @param <T> The type of the response.
-   * @param endpoint The endpoint for the request.
-   * @param method The HTTP method for the request.
+   * Builds the headers for a Patpass API request.
+   * 
    * @param options The options for the request.
-   * @param clazz The class of the response.
+   * @return A map of headers for the request.
+   */
+  public static Map<String, String> buildPatpassHeaders(Options options) {
+    if (null == options)
+      return Collections.emptyMap();
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put(
+        ApiConstants.HEADER_PATPASS_COMMERCE_CODE_NAME,
+        options.getCommerceCode());
+    headers.put(ApiConstants.HEADER_PATPASS_API_KEY_NAME, options.getApiKey());
+
+    return headers;
+  }
+
+  /**
+   * Executes a Webpay API request.
+   * 
+   * @param <T>      The type of the response.
+   * @param endpoint The endpoint for the request.
+   * @param method   The HTTP method for the request.
+   * @param options  The options for the request.
+   * @param clazz    The class of the response.
    * @return The response to the request.
    * @throws TransbankException If an error occurs during the request.
-   * @throws IOException If an error occurs during the request.
+   * @throws IOException        If an error occurs during the request.
    */
   public static <T> T execute(
-    final String endpoint,
-    HttpUtil.RequestMethod method,
-    final Options options,
-    Class<T> clazz
-  ) throws TransbankException, IOException {
+      final String endpoint,
+      HttpUtil.RequestMethod method,
+      final Options options,
+      Class<T> clazz) throws TransbankException, IOException {
     return execute(endpoint, method, null, options, clazz);
   }
 
   /**
    * Executes a Webpay API request with a request body.
-   * @param <T> The type of the response.
+   * 
+   * @param <T>      The type of the response.
    * @param endpoint The endpoint for the request.
-   * @param method The HTTP method for the request.
-   * @param request The request body.
-   * @param options The options for the request.
+   * @param method   The HTTP method for the request.
+   * @param request  The request body.
+   * @param options  The options for the request.
    * @return The response to the request.
    * @throws TransbankException If an error occurs during the request.
-   * @throws IOException If an error occurs during the request.
+   * @throws IOException        If an error occurs during the request.
    */
   public static <T> T execute(
-    final String endpoint,
-    HttpUtil.RequestMethod method,
-    final WebpayApiRequest request,
-    final Options options
-  ) throws TransbankException, IOException {
+      final String endpoint,
+      HttpUtil.RequestMethod method,
+      final WebpayApiRequest request,
+      final Options options) throws TransbankException, IOException {
     return execute(endpoint, method, request, options, null);
   }
 
   /**
    * Executes a Webpay API request with a request body.
-   * @param <T> The type of the response.
+   * 
+   * @param <T>      The type of the response.
    * @param endpoint The endpoint for the request.
-   * @param method The HTTP method for the request.
-   * @param request The request body.
-   * @param options The options for the request.
-   * @param clazz The class of the response.
+   * @param method   The HTTP method for the request.
+   * @param request  The request body.
+   * @param options  The options for the request.
+   * @param clazz    The class of the response.
    * @return The response to the request.
    * @throws TransbankException If an error occurs during the request.
-   * @throws IOException If an error occurs during the request.
+   * @throws IOException        If an error occurs during the request.
    */
   public static <T> T execute(
-    final String endpoint,
-    HttpUtil.RequestMethod method,
-    final WebpayApiRequest request,
-    final Options options,
-    Class<T> clazz
-  ) throws TransbankException, IOException {
+      final String endpoint,
+      HttpUtil.RequestMethod method,
+      final WebpayApiRequest request,
+      final Options options,
+      Class<T> clazz) throws TransbankException, IOException {
     String urlBase = null;
+    Map<String, String> headers = null;
+
     if (options instanceof WebpayOptions) {
-      urlBase =
-        IntegrationTypeHelper.getWebpayIntegrationType(
-          options.getIntegrationType()
-        );
+      urlBase = IntegrationTypeHelper.getWebpayIntegrationType(
+          options.getIntegrationType());
+      headers = WebpayApiResource.buildHeaders(options);
     } else {
-      urlBase =
-        IntegrationTypeHelper.getPatpassIntegrationType(
-          options.getIntegrationType()
-        );
+      urlBase = IntegrationTypeHelper.getPatpassIntegrationType(
+          options.getIntegrationType());
+      headers = WebpayApiResource.buildPatpassHeaders(options);
     }
     final URL url = new URL(String.format("%s/%s", urlBase, endpoint));
 
@@ -121,70 +141,72 @@ public abstract class WebpayApiResource {
     requestInstance.setReadTimeout(options.getTimeout());
 
     final T out = requestInstance.request(
-      url,
-      method,
-      request,
-      WebpayApiResource.buildHeaders(options),
-      clazz
-    );
+        url,
+        method,
+        request,
+        headers,
+        clazz);
 
-    if (null == out) return null;
+    if (null == out)
+      return null;
 
-    if (null == clazz) return null;
+    if (null == clazz)
+      return null;
 
     return out;
   }
 
   /**
    * Executes a Webpay API request and returns a list of responses.
-   * @param <T> The type of the response.
+   * 
+   * @param <T>      The type of the response.
    * @param endpoint The endpoint for the request.
-   * @param method The HTTP method for the request.
-   * @param options The options for the request.
-   * @param clazz The class of the response.
+   * @param method   The HTTP method for the request.
+   * @param options  The options for the request.
+   * @param clazz    The class of the response.
    * @return A list of responses to the request.
    * @throws TransbankException If an error occurs during the request.
-   * @throws IOException If an error occurs during the request.
+   * @throws IOException        If an error occurs during the request.
    */
   public static <T> List<T> executeToList(
-    final String endpoint,
-    HttpUtil.RequestMethod method,
-    final Options options,
-    Class<T[]> clazz
-  ) throws TransbankException, IOException {
+      final String endpoint,
+      HttpUtil.RequestMethod method,
+      final Options options,
+      Class<T[]> clazz) throws TransbankException, IOException {
     return executeToList(endpoint, method, null, options, clazz);
   }
 
   /**
-   * Executes a Webpay API request with a request body and returns a list of responses.
-   * @param <T> The type of the response.
+   * Executes a Webpay API request with a request body and returns a list of
+   * responses.
+   * 
+   * @param <T>      The type of the response.
    * @param endpoint The endpoint for the request.
-   * @param method The HTTP method for the request.
-   * @param request The request body.
-   * @param options The options for the request.
-   * @param clazz The class of the response.
+   * @param method   The HTTP method for the request.
+   * @param request  The request body.
+   * @param options  The options for the request.
+   * @param clazz    The class of the response.
    * @return A list of responses to the request.
    * @throws TransbankException If an error occurs during the request.
-   * @throws IOException If an error occurs during the request.
+   * @throws IOException        If an error occurs during the request.
    */
   public static <T> List<T> executeToList(
-    final String endpoint,
-    HttpUtil.RequestMethod method,
-    final WebpayApiRequest request,
-    final Options options,
-    Class<T[]> clazz
-  ) throws TransbankException, IOException {
+      final String endpoint,
+      HttpUtil.RequestMethod method,
+      final WebpayApiRequest request,
+      final Options options,
+      Class<T[]> clazz) throws TransbankException, IOException {
     String urlBase = null;
+    Map<String, String> headers = null;
+
     if (options instanceof WebpayOptions) {
-      urlBase =
-        IntegrationTypeHelper.getWebpayIntegrationType(
-          options.getIntegrationType()
-        );
+      urlBase = IntegrationTypeHelper.getWebpayIntegrationType(
+          options.getIntegrationType());
+      headers = WebpayApiResource.buildHeaders(options);
     } else {
-      urlBase =
-        IntegrationTypeHelper.getPatpassIntegrationType(
-          options.getIntegrationType()
-        );
+      urlBase = IntegrationTypeHelper.getPatpassIntegrationType(
+          options.getIntegrationType());
+      headers = WebpayApiResource.buildPatpassHeaders(options);
     }
     final URL url = new URL(String.format("%s/%s", urlBase, endpoint));
 
@@ -194,16 +216,17 @@ public abstract class WebpayApiResource {
     requestInstance.setReadTimeout(options.getTimeout());
 
     final List<T> out = requestInstance.requestList(
-      url,
-      method,
-      request,
-      WebpayApiResource.buildHeaders(options),
-      clazz
-    );
+        url,
+        method,
+        request,
+        headers,
+        clazz);
 
-    if (null == out) return Collections.emptyList();
+    if (null == out)
+      return Collections.emptyList();
 
-    if (null == clazz) return Collections.emptyList();
+    if (null == clazz)
+      return Collections.emptyList();
 
     return out;
   }

--- a/src/main/java/cl/transbank/util/WebpayApiResource.java
+++ b/src/main/java/cl/transbank/util/WebpayApiResource.java
@@ -20,6 +20,16 @@ import lombok.Setter;
  */
 public abstract class WebpayApiResource {
 
+  private static final class RequestContext {
+    private final String urlBase;
+    private final Map<String, String> headers;
+
+    private RequestContext(String urlBase, Map<String, String> headers) {
+      this.urlBase = urlBase;
+      this.headers = headers;
+    }
+  }
+
   @Getter
   @Setter
   private static HttpUtil httpUtil = HttpUtilImpl.getInstance();
@@ -31,7 +41,7 @@ public abstract class WebpayApiResource {
    * @return A map of headers for the request.
    */
   public static Map<String, String> buildHeaders(Options options) {
-    if (null == options)
+    if (options == null)
       return Collections.emptyMap();
 
     Map<String, String> headers = new HashMap<>();
@@ -50,7 +60,7 @@ public abstract class WebpayApiResource {
    * @return A map of headers for the request.
    */
   public static Map<String, String> buildPatpassHeaders(Options options) {
-    if (null == options)
+    if (options == null)
       return Collections.emptyMap();
 
     Map<String, String> headers = new HashMap<>();
@@ -121,19 +131,8 @@ public abstract class WebpayApiResource {
       final WebpayApiRequest request,
       final Options options,
       Class<T> clazz) throws TransbankException, IOException {
-    String urlBase = null;
-    Map<String, String> headers = null;
-
-    if (options instanceof WebpayOptions) {
-      urlBase = IntegrationTypeHelper.getWebpayIntegrationType(
-          options.getIntegrationType());
-      headers = WebpayApiResource.buildHeaders(options);
-    } else {
-      urlBase = IntegrationTypeHelper.getPatpassIntegrationType(
-          options.getIntegrationType());
-      headers = WebpayApiResource.buildPatpassHeaders(options);
-    }
-    final URL url = new URL(String.format("%s/%s", urlBase, endpoint));
+    RequestContext requestContext = WebpayApiResource.buildRequestContext(options);
+    final URL url = new URL(String.format("%s/%s", requestContext.urlBase, endpoint));
 
     HttpUtil requestInstance = WebpayApiResource.getHttpUtil();
 
@@ -144,13 +143,13 @@ public abstract class WebpayApiResource {
         url,
         method,
         request,
-        headers,
+        requestContext.headers,
         clazz);
 
-    if (null == out)
+    if (out == null)
       return null;
 
-    if (null == clazz)
+    if (clazz == null)
       return null;
 
     return out;
@@ -196,19 +195,8 @@ public abstract class WebpayApiResource {
       final WebpayApiRequest request,
       final Options options,
       Class<T[]> clazz) throws TransbankException, IOException {
-    String urlBase = null;
-    Map<String, String> headers = null;
-
-    if (options instanceof WebpayOptions) {
-      urlBase = IntegrationTypeHelper.getWebpayIntegrationType(
-          options.getIntegrationType());
-      headers = WebpayApiResource.buildHeaders(options);
-    } else {
-      urlBase = IntegrationTypeHelper.getPatpassIntegrationType(
-          options.getIntegrationType());
-      headers = WebpayApiResource.buildPatpassHeaders(options);
-    }
-    final URL url = new URL(String.format("%s/%s", urlBase, endpoint));
+    RequestContext requestContext = WebpayApiResource.buildRequestContext(options);
+    final URL url = new URL(String.format("%s/%s", requestContext.urlBase, endpoint));
 
     HttpUtil requestInstance = WebpayApiResource.getHttpUtil();
 
@@ -219,15 +207,27 @@ public abstract class WebpayApiResource {
         url,
         method,
         request,
-        headers,
+        requestContext.headers,
         clazz);
 
-    if (null == out)
+    if (out == null)
       return Collections.emptyList();
 
-    if (null == clazz)
+    if (clazz == null)
       return Collections.emptyList();
 
     return out;
+  }
+
+  private static RequestContext buildRequestContext(Options options) {
+    if (options instanceof WebpayOptions) {
+      return new RequestContext(
+          IntegrationTypeHelper.getWebpayIntegrationType(options.getIntegrationType()),
+          WebpayApiResource.buildHeaders(options));
+    }
+
+    return new RequestContext(
+        IntegrationTypeHelper.getPatpassIntegrationType(options.getIntegrationType()),
+        WebpayApiResource.buildPatpassHeaders(options));
   }
 }

--- a/src/test/java/cl/transbank/util/WebpayApiResourceTest.java
+++ b/src/test/java/cl/transbank/util/WebpayApiResourceTest.java
@@ -110,6 +110,35 @@ class WebpayApiResourceTest {
   }
 
   @Test
+  void shouldReturnNullWhenUnderlyingRequestReturnsNull() throws Exception {
+    WebpayOptions options = new WebpayOptions("597012345678", "webpay-api-key", IntegrationType.TEST);
+    when(httpUtil.request(any(URL.class), eq(HttpUtil.RequestMethod.GET), isNull(), anyMap(), eq(String.class)))
+        .thenReturn(null);
+
+    assertNull(WebpayApiResource.execute(
+        "rswebpaytransaction/api/webpay/v1.2/test",
+        HttpUtil.RequestMethod.GET,
+        options,
+        String.class));
+  }
+
+  @Test
+  void shouldReturnListWhenUnderlyingListRequestReturnsValues() throws Exception {
+    PatpassOptions options = new PatpassOptions("28299257", "patpass-api-key", IntegrationType.LIVE);
+    List<String> expected = Arrays.asList("first", "second");
+    when(httpUtil.requestList(any(URL.class), eq(HttpUtil.RequestMethod.POST), isNull(), anyMap(), eq(String[].class)))
+        .thenReturn(expected);
+
+    List<String> response = WebpayApiResource.executeToList(
+        "restpatpass/v1/services/test",
+        HttpUtil.RequestMethod.POST,
+        options,
+        String[].class);
+
+    assertEquals(expected, response);
+  }
+
+  @Test
   void shouldReturnNullOrEmptyListWhenResponseClassIsNull() throws Exception {
     WebpayOptions webpayOptions = new WebpayOptions("597012345678", "webpay-api-key", IntegrationType.LIVE);
     PatpassOptions patpassOptions = new PatpassOptions("28299257", "patpass-api-key", IntegrationType.LIVE);

--- a/src/test/java/cl/transbank/util/WebpayApiResourceTest.java
+++ b/src/test/java/cl/transbank/util/WebpayApiResourceTest.java
@@ -1,0 +1,133 @@
+package cl.transbank.util;
+
+import cl.transbank.common.IntegrationType;
+import cl.transbank.patpass.model.PatpassOptions;
+import cl.transbank.webpay.common.WebpayOptions;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WebpayApiResourceTest {
+
+  private HttpUtil originalHttpUtil;
+  private HttpUtil httpUtil;
+
+  @BeforeEach
+  void setUp() {
+    originalHttpUtil = WebpayApiResource.getHttpUtil();
+    httpUtil = mock(HttpUtil.class);
+    WebpayApiResource.setHttpUtil(httpUtil);
+  }
+
+  @AfterEach
+  void tearDown() {
+    WebpayApiResource.setHttpUtil(originalHttpUtil);
+  }
+
+  @Test
+  void shouldReturnEmptyHeadersWhenWebpayOptionsAreNull() {
+    assertEquals(Collections.emptyMap(), WebpayApiResource.buildHeaders(null));
+  }
+
+  @Test
+  void shouldReturnEmptyHeadersWhenPatpassOptionsAreNull() {
+    assertEquals(Collections.emptyMap(), WebpayApiResource.buildPatpassHeaders(null));
+  }
+
+  @Test
+  void shouldUseWebpayBaseUrlAndHeadersWhenExecutingRequest() throws Exception {
+    WebpayOptions options = new WebpayOptions("597012345678", "webpay-api-key", IntegrationType.TEST);
+    when(httpUtil.request(any(URL.class), eq(HttpUtil.RequestMethod.POST), isNull(), anyMap(), eq(String.class)))
+        .thenReturn("ok");
+
+    String response = WebpayApiResource.execute(
+        "rswebpaytransaction/api/webpay/v1.2/test",
+        HttpUtil.RequestMethod.POST,
+        options,
+        String.class);
+
+    ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
+    ArgumentCaptor<Map> headersCaptor = ArgumentCaptor.forClass(Map.class);
+
+    org.mockito.Mockito.verify(httpUtil).request(
+        urlCaptor.capture(),
+        eq(HttpUtil.RequestMethod.POST),
+        isNull(),
+        headersCaptor.capture(),
+        eq(String.class));
+
+    assertEquals("ok", response);
+    assertEquals(
+        "https://webpay3gint.transbank.cl/rswebpaytransaction/api/webpay/v1.2/test",
+        urlCaptor.getValue().toString());
+    assertEquals("597012345678", headersCaptor.getValue().get("Tbk-Api-Key-Id"));
+    assertEquals("webpay-api-key", headersCaptor.getValue().get("Tbk-Api-Key-Secret"));
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenPatpassListRequestReturnsNull() throws Exception {
+    PatpassOptions options = new PatpassOptions("28299257", "patpass-api-key", IntegrationType.TEST);
+    when(httpUtil.requestList(any(URL.class), eq(HttpUtil.RequestMethod.GET), isNull(), anyMap(), eq(String[].class)))
+        .thenReturn(null);
+
+    List<String> response = WebpayApiResource.executeToList(
+        "restpatpass/v1/services/test",
+        HttpUtil.RequestMethod.GET,
+        options,
+        String[].class);
+
+    ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
+    ArgumentCaptor<Map> headersCaptor = ArgumentCaptor.forClass(Map.class);
+
+    org.mockito.Mockito.verify(httpUtil).requestList(
+        urlCaptor.capture(),
+        eq(HttpUtil.RequestMethod.GET),
+        isNull(),
+        headersCaptor.capture(),
+        eq(String[].class));
+
+    assertEquals(Collections.emptyList(), response);
+    assertEquals(
+        "https://pagoautomaticocontarjetasint.transbank.cl/restpatpass/v1/services/test",
+        urlCaptor.getValue().toString());
+    assertEquals("28299257", headersCaptor.getValue().get("Commercecode"));
+    assertEquals("patpass-api-key", headersCaptor.getValue().get("Authorization"));
+  }
+
+  @Test
+  void shouldReturnNullOrEmptyListWhenResponseClassIsNull() throws Exception {
+    WebpayOptions webpayOptions = new WebpayOptions("597012345678", "webpay-api-key", IntegrationType.LIVE);
+    PatpassOptions patpassOptions = new PatpassOptions("28299257", "patpass-api-key", IntegrationType.LIVE);
+
+    when(httpUtil.request(any(URL.class), eq(HttpUtil.RequestMethod.GET), isNull(), anyMap(), isNull()))
+        .thenReturn("unused");
+    when(httpUtil.requestList(any(URL.class), eq(HttpUtil.RequestMethod.GET), isNull(), anyMap(), isNull()))
+        .thenReturn(Arrays.asList("unused"));
+
+    assertNull(WebpayApiResource.execute(
+        "rswebpaytransaction/api/webpay/v1.2/test",
+        HttpUtil.RequestMethod.GET,
+        webpayOptions,
+        null));
+    assertEquals(Collections.emptyList(), WebpayApiResource.executeToList(
+        "restpatpass/v1/services/test",
+        HttpUtil.RequestMethod.GET,
+        patpassOptions,
+        null));
+  }
+}

--- a/src/test/java/webpayplus/PatpassComercioTest.java
+++ b/src/test/java/webpayplus/PatpassComercioTest.java
@@ -55,7 +55,7 @@ class PatpassComercioTest extends TestBase {
     }
 
     @Test
-    void buildForIntegrationSetsExplicitCredentialValues() {
+    void shouldSetCredentialsAndIntegrationUrlWhenBuildingForIntegration() {
         PatpassComercio.Inscription inscription = PatpassComercio.Inscription.buildForIntegration(
                 BUILDER_COMMERCE_CODE,
                 BUILDER_API_KEY);
@@ -74,7 +74,7 @@ class PatpassComercioTest extends TestBase {
     }
 
     @Test
-    void buildForProductionSetsExplicitCredentialValues() {
+    void shouldSetCredentialsAndProductionUrlWhenBuildingForProduction() {
         PatpassComercio.Inscription inscription = PatpassComercio.Inscription.buildForProduction(
                 BUILDER_COMMERCE_CODE,
                 BUILDER_API_KEY);

--- a/src/test/java/webpayplus/PatpassComercioTest.java
+++ b/src/test/java/webpayplus/PatpassComercioTest.java
@@ -4,6 +4,7 @@ import cl.transbank.common.ApiConstants;
 import cl.transbank.common.IntegrationApiKeys;
 import cl.transbank.common.IntegrationCommerceCodes;
 import cl.transbank.common.IntegrationType;
+import cl.transbank.common.IntegrationTypeHelper;
 import cl.transbank.model.Options;
 import cl.transbank.patpass.PatpassComercio;
 import cl.transbank.patpass.model.PatpassOptions;
@@ -17,17 +18,23 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockserver.model.HttpRequest;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 class PatpassComercioTest extends TestBase {
 
+    private static final String BUILDER_COMMERCE_CODE = "597012345678";
+    private static final String BUILDER_API_KEY = "patpass_builder_api_key";
+    private static final String PATPASS_INTEGRATION_URL = "https://pagoautomaticocontarjetasint.transbank.cl";
+    private static final String PATPASS_PRODUCTION_URL = "https://www.pagoautomaticocontarjetas.cl";
     private static String apiUrl = ApiConstants.PATPASS_COMERCIO_ENDPOINT;
     private static Options option = new PatpassOptions(IntegrationCommerceCodes.PATPASS_COMERCIO,
             IntegrationApiKeys.PATPASS_COMERCIO, IntegrationType.SERVER_MOCK);
@@ -46,6 +53,45 @@ class PatpassComercioTest extends TestBase {
     void resetMockServer() {
         client.reset();
     }
+
+    @Test
+    void buildForIntegrationSetsExplicitCredentialValues() {
+        PatpassComercio.Inscription inscription = PatpassComercio.Inscription.buildForIntegration(
+                BUILDER_COMMERCE_CODE,
+                BUILDER_API_KEY);
+
+        assertNotNull(inscription);
+
+        Options options = inscription.getOptions();
+        assertTrue(options instanceof PatpassOptions);
+
+        PatpassOptions patpassOptions = (PatpassOptions) options;
+        assertEquals(BUILDER_COMMERCE_CODE, patpassOptions.getCommerceCode());
+        assertEquals(BUILDER_API_KEY, patpassOptions.getApiKey());
+        assertEquals(IntegrationType.TEST, patpassOptions.getIntegrationType());
+        assertEquals(PATPASS_INTEGRATION_URL,
+                IntegrationTypeHelper.getPatpassIntegrationType(patpassOptions.getIntegrationType()));
+    }
+
+    @Test
+    void buildForProductionSetsExplicitCredentialValues() {
+        PatpassComercio.Inscription inscription = PatpassComercio.Inscription.buildForProduction(
+                BUILDER_COMMERCE_CODE,
+                BUILDER_API_KEY);
+
+        assertNotNull(inscription);
+
+        Options options = inscription.getOptions();
+        assertTrue(options instanceof PatpassOptions);
+
+        PatpassOptions patpassOptions = (PatpassOptions) options;
+        assertEquals(BUILDER_COMMERCE_CODE, patpassOptions.getCommerceCode());
+        assertEquals(BUILDER_API_KEY, patpassOptions.getApiKey());
+        assertEquals(IntegrationType.LIVE, patpassOptions.getIntegrationType());
+        assertEquals(PATPASS_PRODUCTION_URL,
+                IntegrationTypeHelper.getPatpassIntegrationType(patpassOptions.getIntegrationType()));
+    }
+
     @Test
     void start() throws IOException, InscriptionStartException {
         
@@ -114,5 +160,27 @@ class PatpassComercioTest extends TestBase {
 
         assertTrue(response.isAuthorized());
         assertEquals(response.getVoucherUrl(), urlResponse);
+    }
+
+    @Test
+    void statusSendsPatpassHeadersWithExpectedNamesAndValues() throws IOException, TransactionStatusException {
+        String url = String.format("/%s/status", apiUrl);
+
+        Map<String, Object> mapResponse = new HashMap<String, Object>();
+        mapResponse.put("authorized", (Boolean)true);
+        mapResponse.put("voucherUrl", "https://example.com/voucher");
+
+        Gson gson = new GsonBuilder().create();
+        String jsonResponse = gson.toJson(mapResponse);
+        setResponsePost(url, jsonResponse);
+
+        (new PatpassComercio.Inscription(option)).status(testToken);
+
+        client.verify(
+                new HttpRequest()
+                        .withMethod("POST")
+                        .withPath(url)
+                        .withHeader(ApiConstants.HEADER_PATPASS_COMMERCE_CODE_NAME, option.getCommerceCode())
+                        .withHeader(ApiConstants.HEADER_PATPASS_API_KEY_NAME, option.getApiKey()));
     }
 }

--- a/src/test/java/webpayplus/WebpayPlusTest.java
+++ b/src/test/java/webpayplus/WebpayPlusTest.java
@@ -4,6 +4,7 @@ import cl.transbank.common.ApiConstants;
 import cl.transbank.common.IntegrationApiKeys;
 import cl.transbank.common.IntegrationCommerceCodes;
 import cl.transbank.common.IntegrationType;
+import cl.transbank.common.IntegrationTypeHelper;
 import cl.transbank.model.Options;
 import cl.transbank.webpay.common.WebpayOptions;
 import cl.transbank.webpay.exception.TransactionCommitException;
@@ -27,9 +28,15 @@ import java.util.Map;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 class WebpayPlusTest extends WebpayPlusTestBase {
+    private static final String BUILDER_COMMERCE_CODE = "597012345678";
+    private static final String BUILDER_API_KEY = "webpay_builder_api_key";
+    private static final String WEBPAY_INTEGRATION_URL = "https://webpay3gint.transbank.cl";
+    private static final String WEBPAY_PRODUCTION_URL = "https://webpay3g.transbank.cl";
     private static String apiUrl = ApiConstants.WEBPAY_ENDPOINT;
     private static Options option = new WebpayOptions(IntegrationCommerceCodes.WEBPAY_PLUS,
             IntegrationApiKeys.WEBPAY, IntegrationType.SERVER_MOCK);
@@ -48,6 +55,45 @@ class WebpayPlusTest extends WebpayPlusTestBase {
     void resetMockServer() {
         client.reset();
     }
+
+    @Test
+    void buildForIntegrationSetsExplicitCredentialValuesAndSharedWebpayUrl() {
+        WebpayPlus.Transaction transaction = WebpayPlus.Transaction.buildForIntegration(
+                BUILDER_COMMERCE_CODE,
+                BUILDER_API_KEY);
+
+        assertNotNull(transaction);
+
+        Options options = transaction.getOptions();
+        assertTrue(options instanceof WebpayOptions);
+
+        WebpayOptions webpayOptions = (WebpayOptions) options;
+        assertEquals(BUILDER_COMMERCE_CODE, webpayOptions.getCommerceCode());
+        assertEquals(BUILDER_API_KEY, webpayOptions.getApiKey());
+        assertEquals(IntegrationType.TEST, webpayOptions.getIntegrationType());
+        assertEquals(WEBPAY_INTEGRATION_URL,
+                IntegrationTypeHelper.getWebpayIntegrationType(webpayOptions.getIntegrationType()));
+    }
+
+    @Test
+    void buildForProductionSetsExplicitCredentialValuesAndSharedWebpayUrl() {
+        WebpayPlus.Transaction transaction = WebpayPlus.Transaction.buildForProduction(
+                BUILDER_COMMERCE_CODE,
+                BUILDER_API_KEY);
+
+        assertNotNull(transaction);
+
+        Options options = transaction.getOptions();
+        assertTrue(options instanceof WebpayOptions);
+
+        WebpayOptions webpayOptions = (WebpayOptions) options;
+        assertEquals(BUILDER_COMMERCE_CODE, webpayOptions.getCommerceCode());
+        assertEquals(BUILDER_API_KEY, webpayOptions.getApiKey());
+        assertEquals(IntegrationType.LIVE, webpayOptions.getIntegrationType());
+        assertEquals(WEBPAY_PRODUCTION_URL,
+                IntegrationTypeHelper.getWebpayIntegrationType(webpayOptions.getIntegrationType()));
+    }
+
     @Test
     void create() throws IOException, TransactionCreateException {
         String url = String.format("/%s/transactions", apiUrl);


### PR DESCRIPTION
Refined PATPASS header handling and added regression coverage for credential and base URL configuration in both PATPASS and shared Webpay flows.

For PATPASS, the branch updates the request header usage so the SDK now sends the correct PATPASS-specific header names, `Commercecode` and `Authorization`, instead of reusing the standard Webpay header scheme. To prevent this issue from happening again, we added an HTTP-level regression test that verifies both the exact header names and their expected values in outgoing PATPASS requests.

We also added explicit tests for `PatpassComercio.Inscription.buildForIntegration(...)` and `buildForProduction(...)` to verify that the instance preserves the provided `commerceCode` and `apiKey`, sets the correct `IntegrationType`, and resolves to the expected PATPASS base URL for integration and production.

For Webpay, we added equivalent builder tests in `WebpayPlusTest` as representative coverage for the shared Webpay family, since Webpay products rely on the same base URL resolution logic. These tests validate the explicit credentials passed to the builder together with the resolved base URL for `TEST` and `LIVE`.
